### PR TITLE
docs: add project spec and agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# RelayReel Agent Guidelines
+
+## General Principles
+- **Use established libraries** listed in `Project Specification` whenever possible; avoid reinventing common solutions.
+- **Keep UI and app logic separate**:
+  - Components in `src/components/` must be presentational only.
+  - Hooks in `src/features/` handle state and side effects.
+  - External API interactions reside in `src/services/`.
+
+## Workflow
+1. **Consult library docs** before adding or updating features to ensure correct usage.
+2. Maintain a *big-picture view*: consider how changes affect other modules and the overall architecture.
+3. Run lint, type-check, unit tests, and any Playwright tests before committing.
+4. Do **not** add binary assets (images, videos, etc.) to the repository.
+5. Follow TypeScript, ESLint, and Prettier configurations; keep code and commit messages concise and descriptive.
+6. Include relevant documentation updates and references to `Project Specification` in pull requests.
+
+## Testing Commands
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm test:e2e` (Playwright, if applicable)
+
+Ensure all checks pass before submitting PRs.

--- a/PROJECT_SPEC.md
+++ b/PROJECT_SPEC.md
@@ -1,0 +1,53 @@
+## Project Specification — RelayReel
+
+### Overview
+RelayReel is a TikTok‑style short‑video Progressive Web App powered by the Nostr protocol. The app delivers a swipeable feed of clips, allows creators to upload and receive zaps (Lightning payments), and supports offline usage through PWA features.
+
+### Goals
+1. **Mobile‑first PWA** with installability, offline caching, and fast startup.
+2. **Nostr‑based social graph** for posts, reactions, follows, and zap receipts.
+3. **Clear separation of concerns**: presentational components, feature hooks, and service wrappers.
+
+### Tech Stack
+| Layer/Concern            | Library/Framework                |
+|-------------------------|----------------------------------|
+| Build & Routing         | Next.js (with `next-pwa`)        |
+| UI                      | React + Tailwind CSS             |
+| Animation & Gestures    | Framer Motion                    |
+| State Management        | Zustand                          |
+| Data Storage            | Dexie (IndexedDB)                |
+| Nostr Integration       | nostr-tools                      |
+| Video Playback          | react-player                     |
+| Payments (Lightning)    | lnurl-pay + nostr-tools          |
+| Testing                 | Vitest/Jest + Playwright         |
+
+### High-Level Architecture
+```
+src/
+ ├─ components/           # Pure presentation; no side effects
+ ├─ features/
+ │   ├─ feed/             # useVideoFeed, swipe logic
+ │   ├─ zaps/             # useZap, zap totals
+ │   ├─ upload/           # useUploadVideo
+ │   └─ auth/             # useAuth (NIP-07)
+ ├─ services/
+ │   ├─ nostr.ts          # wrapper around nostr-tools
+ │   ├─ video.ts          # playback utilities (react-player)
+ │   └─ storage.ts        # Dexie persistence, Workbox helpers
+ └─ pages/                # Next.js routes; compose hooks + components
+```
+
+### Core Features
+1. **Swipe Feed**: Vertical carousel of video clips, preloading next/prev items for smooth transitions.
+2. **Video Overlay**: Creator avatar, caption, like/comment/share and Zap button.
+3. **Zap Payments**: Nostr-based lightning payments with zap receipts and total display.
+4. **Upload Flow**: File capture, upload to storage/CDN, publish metadata on Nostr.
+5. **Offline Support**: Workbox precaching, runtime caching for media, background sync for pending uploads.
+6. **Social Interactions**: Likes, comments, follows, and real-time updates via relay subscriptions.
+
+### Testing & Quality
+- Unit tests mock services and feature hooks.
+- Playwright tests emulate mobile devices and PWA install flows.
+- Lighthouse audits enforced in CI.
+- ESLint, Prettier, and TypeScript for code consistency.
+


### PR DESCRIPTION
## Summary
- add project specification outlining architecture, tech stack, and features
- document workflow and testing expectations in AGENTS guidelines

## Testing
- `pnpm lint` *(fails: No package.json found)*
- `pnpm typecheck` *(fails: No package.json found)*
- `pnpm test` *(fails: No package.json found)*
- `pnpm test:e2e` *(fails: No package.json found)*

------
https://chatgpt.com/codex/tasks/task_e_6899e72d39c88331bea958afd07dbd2e