### PR TITLE
feat: add nostr service singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # RelayReel
 Nostr based short videos
+
+## Feature Hook Usage
+- **useAuth**: establishes a signer (browser NIP-07 or remote NIP-46) and connects to the user's preferred relays via `NostrService.connect`.
+- **useVideoFeed**: fetches and listens for video events by calling `NostrService.subscribe` with feed filters.
+- **useZap**: signs and publishes zap events through `NostrService.publish`, also subscribing for zap receipts.
+- **useUploadVideo**: uploads media and publishes metadata using `NostrService.publish`, verifying published events with `NostrService.verify`.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "next": "^15.4.6",
+    "nostr-tools": "^2",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       next:
         specifier: ^15.4.6
         version: 15.4.6(@playwright/test@1.54.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      nostr-tools:
+        specifier: ^2
+        version: 2.16.2(typescript@5.9.2)
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -517,6 +520,23 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/ciphers@0.5.3':
+    resolution: {integrity: sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w==}
+
+  '@noble/curves@1.1.0':
+    resolution: {integrity: sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==}
+
+  '@noble/curves@1.2.0':
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+
+  '@noble/hashes@1.3.1':
+    resolution: {integrity: sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==}
+    engines: {node: '>= 16'}
+
+  '@noble/hashes@1.3.2':
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -643,6 +663,15 @@ packages:
 
   '@rushstack/eslint-patch@1.12.0':
     resolution: {integrity: sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==}
+
+  '@scure/base@1.1.1':
+    resolution: {integrity: sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==}
+
+  '@scure/bip32@1.3.1':
+    resolution: {integrity: sha512-osvveYtyzdEVbt3OfwwXFr4P2iVBL5u1Q3q4ONBfDY/UpOuXmOlbgwc1xECEboY8wIays8Yt6onaWMUdUbfl0A==}
+
+  '@scure/bip39@1.2.1':
+    resolution: {integrity: sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1776,6 +1805,17 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
+  nostr-tools@2.16.2:
+    resolution: {integrity: sha512-ZxH9EbSt5ypURZj2TGNJxZd0Omb5ag5KZSu8IyJMCdLyg2KKz+2GA0sP/cSawCQEkyviIN4eRT4G2gB/t9lMRw==}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  nostr-wasm@0.1.0:
+    resolution: {integrity: sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA==}
+
   nwsapi@2.2.21:
     resolution: {integrity: sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==}
 
@@ -2689,6 +2729,20 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.4.6':
     optional: true
 
+  '@noble/ciphers@0.5.3': {}
+
+  '@noble/curves@1.1.0':
+    dependencies:
+      '@noble/hashes': 1.3.1
+
+  '@noble/curves@1.2.0':
+    dependencies:
+      '@noble/hashes': 1.3.2
+
+  '@noble/hashes@1.3.1': {}
+
+  '@noble/hashes@1.3.2': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2770,6 +2824,19 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.12.0': {}
+
+  '@scure/base@1.1.1': {}
+
+  '@scure/bip32@1.3.1':
+    dependencies:
+      '@noble/curves': 1.1.0
+      '@noble/hashes': 1.3.1
+      '@scure/base': 1.1.1
+
+  '@scure/bip39@1.2.1':
+    dependencies:
+      '@noble/hashes': 1.3.1
+      '@scure/base': 1.1.1
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -4121,6 +4188,20 @@ snapshots:
   node-releases@2.0.19: {}
 
   normalize-range@0.1.2: {}
+
+  nostr-tools@2.16.2(typescript@5.9.2):
+    dependencies:
+      '@noble/ciphers': 0.5.3
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.1
+      '@scure/base': 1.1.1
+      '@scure/bip32': 1.3.1
+      '@scure/bip39': 1.2.1
+      nostr-wasm: 0.1.0
+    optionalDependencies:
+      typescript: 5.9.2
+
+  nostr-wasm@0.1.0: {}
 
   nwsapi@2.2.21: {}
 

--- a/src/services/nostr.ts
+++ b/src/services/nostr.ts
@@ -1,0 +1,96 @@
+import { SimplePool, verifyEvent, type Event, type Filter, type UnsignedEvent, type EventTemplate } from 'nostr-tools';
+
+/** Minimal signer interface implemented by both NIP-07 and NIP-46 signers. */
+interface SignerLike {
+  getPublicKey(): Promise<string>;
+  signEvent(event: EventTemplate): Promise<Event>;
+}
+
+export type Nip07Signer = SignerLike;
+export type Nip46Signer = SignerLike;
+
+/** Handlers used when subscribing to relays. */
+export interface SubscriptionHandlers {
+  onEvent: (event: Event) => void;
+  onEose?: () => void;
+  onClose?: (reasons: string[]) => void;
+}
+
+/**
+ * NostrService centralises relay connections and signing logic.
+ * It follows a singleton pattern so feature hooks can share a single pool.
+ */
+class NostrService {
+  private static instance: NostrService;
+
+  private pool: SimplePool;
+  private relays: Set<string> = new Set();
+  private signer?: Nip07Signer | Nip46Signer;
+
+  private constructor() {
+    this.pool = new SimplePool();
+  }
+
+  /** Return the singleton instance. */
+  static getInstance(): NostrService {
+    if (!NostrService.instance) {
+      NostrService.instance = new NostrService();
+    }
+    return NostrService.instance;
+  }
+
+  /**
+   * Connect to a set of relay URLs. Previous connections not in the new list are closed.
+   */
+  async connect(relayUrls: string[]): Promise<void> {
+    const next = new Set(relayUrls);
+    // Close dropped relays
+    const toClose = [...this.relays].filter((r) => !next.has(r));
+    if (toClose.length > 0) {
+      this.pool.close(toClose);
+      toClose.forEach((r) => this.relays.delete(r));
+    }
+    // Ensure new connections
+    await Promise.all(
+      [...next].map(async (url) => {
+        if (!this.relays.has(url)) {
+          await this.pool.ensureRelay(url);
+          this.relays.add(url);
+        }
+      })
+    );
+  }
+
+  /** Set the active signer, either a Nip07 or Nip46 implementation. */
+  setSigner(signer: Nip07Signer | Nip46Signer): void {
+    this.signer = signer;
+  }
+
+  /** Sign and publish an event to all connected relays. */
+  async publish(event: UnsignedEvent): Promise<Event> {
+    if (!this.signer) {
+      throw new Error('no signer configured');
+    }
+    const { pubkey: _pubkey, ...template } = event;
+    const signed = await this.signer.signEvent(template as EventTemplate);
+    await Promise.all(this.pool.publish([...this.relays], signed));
+    return signed;
+  }
+
+  /** Subscribe to a set of filters across all connected relays. */
+  subscribe(filters: Filter[], handlers: SubscriptionHandlers): () => void {
+    const sub = this.pool.subscribeMany([...this.relays], filters, {
+      onevent: handlers.onEvent,
+      oneose: handlers.onEose,
+      onclose: handlers.onClose,
+    });
+    return () => sub.close();
+  }
+
+  /** Verify the signature of an event. */
+  verify(event: Event): boolean {
+    return verifyEvent(event);
+  }
+}
+
+export default NostrService.getInstance();


### PR DESCRIPTION
## Summary
- add nostr-tools dependency and initialize relay service
- document feature hook usage patterns
- implement NostrService with connection, signer, publish, subscribe, verify helpers

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` *(fails: No test files found, exiting with code 1)*
- `pnpm test:e2e` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689a5369c6388331b439a56434da2d85