### PR TITLE
feat: add NIP-07 auth and remote signer

### DIFF
--- a/PROJECT_SPEC.md
+++ b/PROJECT_SPEC.md
@@ -6,8 +6,9 @@ RelayReel is a TikTok‑style short‑video Progressive Web App powered by the N
 ### Goals
 1. **Mobile‑first PWA** with installability, offline caching, and fast startup.
 2. **Nostr‑based social graph** for posts, reactions, follows, and zap receipts.
-3. **Clear separation of concerns**: presentational components, feature hooks, and service wrappers.
-4. **Resource‑aware implementation**: evaluate network usage, server load, device memory and storage, and responsiveness before writing code.
+3. **Remote signer support** (NIP‑46) for delegated event signing alongside NIP‑07 browser extensions.
+4. **Clear separation of concerns**: presentational components, feature hooks, and service wrappers.
+5. **Resource‑aware implementation**: evaluate network usage, server load, device memory and storage, and responsiveness before writing code.
 
 ### Tech Stack
 | Layer/Concern            | Library/Framework                |
@@ -30,7 +31,7 @@ src/
  │   ├─ feed/             # useVideoFeed, swipe logic
  │   ├─ zaps/             # useZap, zap totals
  │   ├─ upload/           # useUploadVideo
- │   └─ auth/             # useAuth (NIP-07)
+ │   └─ auth/             # useAuth (NIP-07) & useRemoteSigner (NIP-46)
  ├─ services/
  │   ├─ nostr.ts          # wrapper around nostr-tools
  │   ├─ video.ts          # playback utilities (react-player)

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "workbox-background-sync": "^7.3.0",
     "workbox-precaching": "^7.3.0",
     "workbox-routing": "^7.3.0",
-    "workbox-strategies": "^7.3.0"
+    "workbox-strategies": "^7.3.0",
+    "zustand": "^4"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       workbox-strategies:
         specifier: ^7.3.0
         version: 7.3.0
+      zustand:
+        specifier: ^4
+        version: 4.5.7(@types/react@19.1.9)(react@19.1.1)
     devDependencies:
       '@playwright/test':
         specifier: ^1.54.2
@@ -3796,6 +3799,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-sync-external-store@1.5.0:
+    resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -4072,6 +4080,21 @@ packages:
 
   youtube-video-element@1.6.2:
     resolution: {integrity: sha512-YHDIOAqgRpfl1Ois9HcB8UFtWOxK8KJrV5TXpImj4BKYP1rWT04f/fMM9tQ9SYZlBKukT7NR+9wcI3UpB5BMDQ==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
 snapshots:
 
@@ -8207,6 +8230,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-sync-external-store@1.5.0(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+
   util-deprecate@1.0.2: {}
 
   util@0.12.5:
@@ -8589,3 +8616,10 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   youtube-video-element@1.6.2: {}
+
+  zustand@4.5.7(@types/react@19.1.9)(react@19.1.1):
+    dependencies:
+      use-sync-external-store: 1.5.0(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.9
+      react: 19.1.1

--- a/src/features/auth/useAuth.test.ts
+++ b/src/features/auth/useAuth.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import { useAuthStore } from './useAuth';
+
+beforeEach(() => {
+  useAuthStore.setState({ pubkey: undefined, method: undefined, signer: undefined });
+});
+
+afterEach(() => {
+  // cleanup global nostr and store
+  // eslint-disable-next-line
+  delete (globalThis as any).nostr;
+});
+
+test('connectExtension requests pubkey once and stores session', async () => {
+  const getPublicKey = vi.fn().mockResolvedValue('npub123');
+  const fakeSigner = { getPublicKey, signEvent: vi.fn() };
+  // eslint-disable-next-line
+  (globalThis as any).nostr = fakeSigner;
+
+  const { connectExtension } = useAuthStore.getState();
+  const [a, b] = await Promise.all([connectExtension(), connectExtension()]);
+
+  expect(a).toBe('npub123');
+  expect(b).toBe('npub123');
+  expect(getPublicKey).toHaveBeenCalledTimes(1);
+  expect(useAuthStore.getState().pubkey).toBe('npub123');
+  expect(useAuthStore.getState().method).toBe('nip07');
+});

--- a/src/features/auth/useAuth.ts
+++ b/src/features/auth/useAuth.ts
@@ -1,0 +1,48 @@
+import { create } from 'zustand';
+import NostrService, {
+  type Nip07Signer,
+  type Nip46Signer,
+} from '../../services/nostr';
+
+export type AuthMethod = 'nip07' | 'nip46';
+
+interface AuthState {
+  pubkey?: string;
+  method?: AuthMethod;
+  signer?: Nip07Signer | Nip46Signer;
+  connectExtension: () => Promise<string>;
+  logout: () => void;
+  setSigner: (pubkey: string, signer: Nip07Signer | Nip46Signer, method: AuthMethod) => void;
+}
+
+let nip07Request: Promise<string> | undefined;
+
+export const useAuthStore = create<AuthState>((set) => ({
+  async connectExtension() {
+    const nostr = (globalThis as any).nostr as Nip07Signer | undefined;
+    if (!nostr) {
+      throw new Error('NIP-07 extension not available');
+    }
+    if (!nip07Request) {
+      nip07Request = nostr.getPublicKey().then((pubkey) => {
+        set({ pubkey, method: 'nip07', signer: nostr });
+        NostrService.setSigner(nostr);
+        return pubkey;
+      });
+    }
+    return nip07Request;
+  },
+  logout() {
+    nip07Request = undefined;
+    set({ pubkey: undefined, method: undefined, signer: undefined });
+    NostrService.setSigner();
+  },
+  setSigner(pubkey, signer, method) {
+    set({ pubkey, signer, method });
+    NostrService.setSigner(signer);
+  },
+}));
+
+export default function useAuth() {
+  return useAuthStore();
+}

--- a/src/features/auth/useRemoteSigner.ts
+++ b/src/features/auth/useRemoteSigner.ts
@@ -1,0 +1,40 @@
+import { useCallback, useRef, useState } from 'react';
+import { BunkerSigner, parseBunkerInput } from 'nostr-tools/nip46';
+import { generateSecretKey } from 'nostr-tools';
+import NostrService from '../../services/nostr';
+import { useAuthStore } from './useAuth';
+
+export default function useRemoteSigner() {
+  const [signer, setSigner] = useState<BunkerSigner>();
+  const connectRef = useRef<Promise<string> | null>(null);
+
+  const connect = useCallback(async (input: string) => {
+    if (connectRef.current) return connectRef.current;
+
+    connectRef.current = (async () => {
+      const bp = await parseBunkerInput(input);
+      if (!bp) throw new Error('invalid bunker pointer');
+      const pool = NostrService.getPool();
+      const localSecret = generateSecretKey();
+      const rs = new BunkerSigner(localSecret, bp, { pool });
+      await rs.connect();
+      const pubkey = await rs.getPublicKey();
+      useAuthStore.getState().setSigner(pubkey, rs, 'nip46');
+      setSigner(rs);
+      return pubkey;
+    })();
+
+    return connectRef.current;
+  }, []);
+
+  const disconnect = useCallback(async () => {
+    connectRef.current = null;
+    if (signer) {
+      await signer.close();
+    }
+    setSigner(undefined);
+    useAuthStore.getState().logout();
+  }, [signer]);
+
+  return { connect, disconnect, signer };
+}

--- a/src/services/nostr.ts
+++ b/src/services/nostr.ts
@@ -76,9 +76,14 @@ class NostrService {
     );
   }
 
-  /** Set the active signer, either a Nip07 or Nip46 implementation. */
-  setSigner(signer: Nip07Signer | Nip46Signer): void {
+  /** Set or clear the active signer. */
+  setSigner(signer?: Nip07Signer | Nip46Signer): void {
     this.signer = signer;
+  }
+
+  /** Expose the underlying SimplePool so other modules can reuse network connections. */
+  getPool(): SimplePool {
+    return this.pool;
   }
 
   /** Sign and publish an event to all connected relays. */

--- a/src/types/nip46.d.ts
+++ b/src/types/nip46.d.ts
@@ -1,0 +1,3 @@
+declare module 'nostr-tools/nip46' {
+  export * from 'nostr-tools/lib/types/nip46';
+}


### PR DESCRIPTION
## Summary
- manage auth session with Zustand, detecting NIP-07 extension
- add NIP-46 remote signer hook sharing relay pool
- document remote signer support in project spec

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689a6d7d2574833193791c0275013221