### PR TITLE
feat: add resource-aware video feed hook

### DIFF
--- a/PROJECT_SPEC.md
+++ b/PROJECT_SPEC.md
@@ -40,7 +40,7 @@ src/
 ```
 
 ### Core Features
-1. **Swipe Feed**: Vertical carousel of video clips, preloading next/prev items for smooth transitions.
+1. **Swipe Feed**: Vertical carousel of video clips, preloading next/prev items for smooth transitions. Feed requests must reuse active filters and deduplicate network calls to stay resource-aware.
 2. **Video Overlay**: Creator avatar, caption, like/comment/share and Zap button.
 3. **Zap Payments**: Nostr-based lightning payments with zap receipts and total display.
 4. **Upload Flow**: File capture, upload to storage/CDN, publish metadata on Nostr.

--- a/src/features/feed/useVideoFeed.test.ts
+++ b/src/features/feed/useVideoFeed.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import type { Event, Filter } from 'nostr-tools';
+import NostrService from '../../services/nostr';
+import { useVideoFeedStore, __clearFeedCache } from './useVideoFeed';
+
+const sampleEvents: Event[] = [
+  {
+    id: '1',
+    kind: 1,
+    pubkey: 'pk1',
+    created_at: 0,
+    sig: 'sig1',
+    tags: [],
+    content: 'https://example.com/a.mp4'
+  },
+  {
+    id: '2',
+    kind: 1,
+    pubkey: 'pk2',
+    created_at: 0,
+    sig: 'sig2',
+    tags: [],
+    content: 'https://example.com/b.mp4'
+  }
+];
+
+const filters: Filter[] = [{ kinds: [1] }];
+
+beforeEach(() => {
+  useVideoFeedStore.setState({ events: [], index: 0, key: undefined });
+  __clearFeedCache();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('setFilters caches results and avoids duplicate queries', async () => {
+  const query = vi.spyOn(NostrService, 'query').mockResolvedValue(sampleEvents);
+  const { setFilters } = useVideoFeedStore.getState();
+  await setFilters(filters);
+  await setFilters(filters);
+  expect(query).toHaveBeenCalledTimes(1);
+});
+
+test('next and prev update index and preload links', async () => {
+  vi.spyOn(NostrService, 'query').mockResolvedValue(sampleEvents);
+  const { setFilters, next, prev } = useVideoFeedStore.getState();
+  await setFilters(filters);
+  expect(useVideoFeedStore.getState().index).toBe(0);
+  // link for next video should be preloaded
+  expect(
+    document.head.querySelector('link[rel="preload"][href="https://example.com/b.mp4"]')
+  ).toBeTruthy();
+  next();
+  expect(useVideoFeedStore.getState().index).toBe(1);
+  // prev link should now be preloaded
+  expect(
+    document.head.querySelector('link[rel="preload"][href="https://example.com/a.mp4"]')
+  ).toBeTruthy();
+  prev();
+  expect(useVideoFeedStore.getState().index).toBe(0);
+});
+

--- a/src/features/feed/useVideoFeed.ts
+++ b/src/features/feed/useVideoFeed.ts
@@ -1,0 +1,112 @@
+import { create } from 'zustand';
+import { useEffect } from 'react';
+import type { Event, Filter } from 'nostr-tools';
+import NostrService from '../../services/nostr';
+
+interface FeedState {
+  events: Event[];
+  index: number;
+  key?: string;
+  setFilters: (filters: Filter[]) => Promise<void>;
+  next: () => void;
+  prev: () => void;
+}
+
+// Cache resolved queries so repeated filter sets reuse network results
+const resultsCache = new Map<string, Event[]>();
+// Track in-flight requests to deduplicate concurrent calls
+const inflight = new Map<string, Promise<Event[]>>();
+// Track preloaded URLs to avoid redundant DOM nodes
+const preloaded = new Set<string>();
+
+async function fetchEvents(filters: Filter[]): Promise<Event[]> {
+  const key = JSON.stringify(filters);
+  const cached = resultsCache.get(key);
+  if (cached) return cached;
+
+  let promise = inflight.get(key);
+  if (!promise) {
+    promise = NostrService.query(filters);
+    inflight.set(key, promise);
+  }
+  const events = await promise;
+  inflight.delete(key);
+  resultsCache.set(key, events);
+  return events;
+}
+
+function preloadUrl(url?: string): void {
+  if (!url || preloaded.has(url)) return;
+  const link = document.createElement('link');
+  link.rel = 'preload';
+  link.as = 'video';
+  link.href = url;
+  document.head.appendChild(link);
+  preloaded.add(url);
+}
+
+function preloadAround(idx: number, events: Event[]): void {
+  preloadUrl(events[idx + 1]?.content);
+  preloadUrl(events[idx - 1]?.content);
+}
+
+export const useVideoFeedStore = create<FeedState>((set, get) => ({
+  events: [],
+  index: 0,
+  key: undefined,
+  async setFilters(filters) {
+    const key = JSON.stringify(filters);
+    if (get().key === key) return;
+    set({ key, index: 0, events: [] });
+    const events = await fetchEvents(filters);
+    set({ events });
+    preloadAround(0, events);
+  },
+  next() {
+    const { index, events } = get();
+    if (index < events.length - 1) {
+      const nextIndex = index + 1;
+      set({ index: nextIndex });
+      preloadAround(nextIndex, events);
+    }
+  },
+  prev() {
+    const { index, events } = get();
+    if (index > 0) {
+      const prevIndex = index - 1;
+      set({ index: prevIndex });
+      preloadAround(prevIndex, events);
+    }
+  }
+}));
+
+export function __clearFeedCache(): void {
+  resultsCache.clear();
+  inflight.clear();
+  preloaded.clear();
+  // remove existing preload links
+  Array.from(document.head.querySelectorAll('link[rel="preload"][as="video"]')).forEach((el) =>
+    el.parentElement?.removeChild(el)
+  );
+}
+
+export default function useVideoFeed(filters: Filter[]): {
+  currentVideo?: Event;
+  next: () => void;
+  prev: () => void;
+} {
+  const { events, index, setFilters, next, prev } = useVideoFeedStore();
+
+  useEffect(() => {
+    setFilters(filters).catch(() => {
+      /* swallow errors so UI can handle empty feeds */
+    });
+  }, [filters, setFilters]);
+
+  return {
+    currentVideo: events[index],
+    next,
+    prev
+  };
+}
+


### PR DESCRIPTION
## Summary
- add `useVideoFeed` hook that caches feed queries and preloads adjacent videos
- cover feed hook with tests
- note in spec that feed requests must deduplicate and reuse active filters

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689a6f75994483318a60129017c49e11