### PR TITLE
feat(auth): add nip07 login

### DIFF
--- a/src/features/auth/useAuth.test.ts
+++ b/src/features/auth/useAuth.test.ts
@@ -11,18 +11,20 @@ afterEach(() => {
   delete (globalThis as any).nostr;
 });
 
-test('connectExtension requests pubkey once and stores session', async () => {
+test('login requests pubkey and signs once, storing session', async () => {
   const getPublicKey = vi.fn().mockResolvedValue('npub123');
-  const fakeSigner = { getPublicKey, signEvent: vi.fn() };
+  const signEvent = vi.fn().mockResolvedValue({});
+  const fakeSigner = { getPublicKey, signEvent };
   // eslint-disable-next-line
   (globalThis as any).nostr = fakeSigner;
 
-  const { connectExtension } = useAuthStore.getState();
-  const [a, b] = await Promise.all([connectExtension(), connectExtension()]);
+  const { login } = useAuthStore.getState();
+  const [a, b] = await Promise.all([login(), login()]);
 
   expect(a).toBe('npub123');
   expect(b).toBe('npub123');
   expect(getPublicKey).toHaveBeenCalledTimes(1);
+  expect(signEvent).toHaveBeenCalledTimes(1);
   expect(useAuthStore.getState().pubkey).toBe('npub123');
   expect(useAuthStore.getState().method).toBe('nip07');
 });


### PR DESCRIPTION
## Summary
- add Zustand-based login/logout for NIP-07 browser extension
- request both `getPublicKey` and a dummy `signEvent` to confirm signing permissions
- cover login flow with unit tests

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689a942a2e448331aa90e16d5300f292