### PR TITLE
feat: add NIP-46 remote signer

### DIFF
--- a/src/features/auth/useAuth.test.ts
+++ b/src/features/auth/useAuth.test.ts
@@ -28,3 +28,13 @@ test('login requests pubkey and signs once, storing session', async () => {
   expect(useAuthStore.getState().pubkey).toBe('npub123');
   expect(useAuthStore.getState().method).toBe('nip07');
 });
+
+test('login returns remote pubkey when remote signer connected', async () => {
+  const remoteSigner = { getPublicKey: vi.fn(), signEvent: vi.fn() } as any;
+  useAuthStore.getState().setSigner('remote123', remoteSigner, 'nip46');
+
+  const { login } = useAuthStore.getState();
+  const pubkey = await login();
+
+  expect(pubkey).toBe('remote123');
+});

--- a/src/features/auth/useAuth.ts
+++ b/src/features/auth/useAuth.ts
@@ -22,8 +22,13 @@ interface AuthState {
 
 let loginRequest: Promise<string> | undefined;
 
-export const useAuthStore = create<AuthState>((set) => ({
+export const useAuthStore = create<AuthState>((set, get) => ({
   async login() {
+    const current = get();
+    if (current.signer && current.method === 'nip46' && current.pubkey) {
+      return current.pubkey;
+    }
+
     const nostr = (globalThis as any).nostr as Nip07Signer | undefined;
     if (!nostr || typeof nostr.getPublicKey !== 'function' || typeof nostr.signEvent !== 'function') {
       throw new Error('NIP-07 extension not available');

--- a/src/features/auth/useRemoteSigner.test.ts
+++ b/src/features/auth/useRemoteSigner.test.ts
@@ -1,0 +1,59 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { beforeEach, expect, test, vi } from 'vitest';
+import useRemoteSigner from './useRemoteSigner';
+import { useAuthStore } from './useAuth';
+
+const { mockSetSigner, mockGetPool } = vi.hoisted(() => ({
+  mockSetSigner: vi.fn(),
+  mockGetPool: vi.fn()
+}));
+
+vi.mock('../../services/nostr', () => ({
+  default: { getPool: mockGetPool, setSigner: mockSetSigner }
+}));
+
+const connect = vi.fn().mockResolvedValue(undefined);
+const getPublicKey = vi.fn().mockResolvedValue('remote123');
+const signEvent = vi.fn().mockResolvedValue({ id: '1' });
+const close = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('nostr-tools/nip46', () => ({
+  parseBunkerInput: vi.fn().mockResolvedValue({ relays: [], pubkey: 'remote', secret: null }),
+  BunkerSigner: vi.fn().mockImplementation(() => ({
+    connect,
+    getPublicKey,
+    signEvent,
+    close
+  }))
+}));
+
+beforeEach(() => {
+  localStorage.clear();
+  connect.mockClear();
+  getPublicKey.mockClear();
+  signEvent.mockClear();
+  close.mockClear();
+  mockSetSigner.mockClear();
+  mockGetPool.mockClear();
+  useAuthStore.setState({ pubkey: undefined, method: undefined, signer: undefined });
+});
+
+test('connectRemote persists session and allows signing', async () => {
+  const { result } = renderHook(() => useRemoteSigner());
+  await act(async () => {
+    const pub = await result.current.connectRemote('input');
+    expect(pub).toBe('remote123');
+  });
+  expect(localStorage.getItem('nip46-session')).toBeTruthy();
+  await act(async () => {
+    await result.current.signRemoteEvent({ kind: 1, created_at: 0, tags: [], content: '' });
+  });
+  expect(signEvent).toHaveBeenCalled();
+});
+
+test('restores session from storage', async () => {
+  localStorage.setItem('nip46-session', JSON.stringify({ input: 'input', secret: 'aa' }));
+  const { result } = renderHook(() => useRemoteSigner());
+  await waitFor(() => expect(result.current.signer).toBeDefined());
+  expect(connect).toHaveBeenCalled();
+});

--- a/src/features/auth/useRemoteSigner.ts
+++ b/src/features/auth/useRemoteSigner.ts
@@ -1,14 +1,50 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { BunkerSigner, parseBunkerInput } from 'nostr-tools/nip46';
 import { generateSecretKey } from 'nostr-tools';
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const matches = hex.match(/.{1,2}/g) || [];
+  return Uint8Array.from(matches.map((b) => parseInt(b, 16)));
+}
 import NostrService from '../../services/nostr';
 import { useAuthStore } from './useAuth';
+
+const SESSION_KEY = 'nip46-session';
 
 export default function useRemoteSigner() {
   const [signer, setSigner] = useState<BunkerSigner>();
   const connectRef = useRef<Promise<string> | null>(null);
 
-  const connect = useCallback(async (input: string) => {
+  // Restore previous session if available
+  useEffect(() => {
+    const raw = typeof window !== 'undefined' ? localStorage.getItem(SESSION_KEY) : null;
+    if (!raw) return;
+    const { input, secret } = JSON.parse(raw);
+
+    (async () => {
+      try {
+        const bp = await parseBunkerInput(input);
+        if (!bp) throw new Error('invalid bunker pointer');
+        const pool = NostrService.getPool();
+        const rs = new BunkerSigner(hexToBytes(secret), bp, { pool });
+        await rs.connect();
+        const pubkey = await rs.getPublicKey();
+        useAuthStore.getState().setSigner(pubkey, rs, 'nip46');
+        setSigner(rs);
+      } catch (err) {
+        localStorage.removeItem(SESSION_KEY);
+        console.error('failed to restore NIP-46 session', err);
+      }
+    })();
+  }, []);
+
+  const connectRemote = useCallback(async (input: string) => {
     if (connectRef.current) return connectRef.current;
 
     connectRef.current = (async () => {
@@ -21,11 +57,23 @@ export default function useRemoteSigner() {
       const pubkey = await rs.getPublicKey();
       useAuthStore.getState().setSigner(pubkey, rs, 'nip46');
       setSigner(rs);
+      localStorage.setItem(
+        SESSION_KEY,
+        JSON.stringify({ input, secret: bytesToHex(localSecret) })
+      );
       return pubkey;
     })();
 
     return connectRef.current;
   }, []);
+
+  const signRemoteEvent = useCallback(
+    async (evt: Parameters<BunkerSigner['signEvent']>[0]) => {
+      if (!signer) throw new Error('remote signer not connected');
+      return signer.signEvent(evt);
+    },
+    [signer]
+  );
 
   const disconnect = useCallback(async () => {
     connectRef.current = null;
@@ -33,8 +81,9 @@ export default function useRemoteSigner() {
       await signer.close();
     }
     setSigner(undefined);
+    localStorage.removeItem(SESSION_KEY);
     useAuthStore.getState().logout();
   }, [signer]);
 
-  return { connect, disconnect, signer };
+  return { connectRemote, signRemoteEvent, disconnect, signer };
 }


### PR DESCRIPTION
## Summary
- integrate NIP-46 remote signer hook with connectRemote, signRemoteEvent, and session persistence
- prefer remote signer in auth store when session exists
- add unit tests for remote signer and auth preferences

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689aac0785748331a89a54d15848ad5e