### PR TITLE
feat(feed): cache events and preload videos

### DIFF
--- a/src/services/video.tsx
+++ b/src/services/video.tsx
@@ -111,3 +111,26 @@ export function createPlayer(
   return { Player, load, play, pause, seek, preload };
 }
 
+// Track preloaded video URLs to avoid duplicate DOM nodes
+const preloaded = new Set<string>();
+
+/** Preload a single video URL using a <link rel="preload"> tag. */
+export function preloadVideo(url?: string): void {
+  if (!url || preloaded.has(url)) return;
+  const link = document.createElement("link");
+  link.rel = "preload";
+  link.as = "video";
+  link.href = url;
+  document.head.appendChild(link);
+  preloaded.add(url);
+}
+
+/** Clear preloaded video links (used in tests). */
+export function clearPreloadedVideos(): void {
+  preloaded.clear();
+  Array.from(
+    document.head.querySelectorAll('link[rel="preload"][as="video"]')
+  ).forEach((el) => el.parentElement?.removeChild(el));
+}
+
+


### PR DESCRIPTION
## Summary
- store video event metadata with current index in Zustand
- fetch events via NostrService.subscribe and cache results
- prefetch adjacent videos through shared video service

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689aaed08d8c8331b29e90a84354617b