### PR TITLE
feat: add zap hook

### DIFF
--- a/src/features/zaps/useZap.test.ts
+++ b/src/features/zaps/useZap.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+import { useZapStore } from './useZap';
+
+vi.mock('../../services/lightning', () => ({
+  fetchInvoice: vi.fn().mockResolvedValue({ invoice: 'lninv', metadata: {} }),
+  sendZap: vi.fn().mockResolvedValue({ status: 'ok' }),
+}));
+
+vi.mock('../../services/nostr', () => ({
+  __esModule: true,
+  default: { publish: vi.fn().mockResolvedValue({ id: 'event1' }) },
+}));
+
+import { fetchInvoice, sendZap } from '../../services/lightning';
+import NostrService from '../../services/nostr';
+
+beforeEach(() => {
+  useZapStore.setState({ sending: false, error: undefined });
+  vi.clearAllMocks();
+});
+
+test('zap fetches invoice, publishes event, and sends payment', async () => {
+  const { zap, sending } = useZapStore.getState();
+  expect(sending).toBe(false);
+  await zap('lnurl1', 21, 'pubkey1');
+  expect(fetchInvoice).toHaveBeenCalledWith('lnurl1', 21);
+  expect(NostrService.publish).toHaveBeenCalled();
+  expect(sendZap).toHaveBeenCalledWith('lninv', { id: 'event1' }, 'lnurl1');
+  expect(useZapStore.getState().sending).toBe(false);
+  expect(useZapStore.getState().error).toBeUndefined();
+});
+

--- a/src/features/zaps/useZap.ts
+++ b/src/features/zaps/useZap.ts
@@ -1,0 +1,49 @@
+import { create } from 'zustand';
+import type { UnsignedEvent, Event } from 'nostr-tools';
+import NostrService from '../../services/nostr';
+import { fetchInvoice, sendZap } from '../../services/lightning';
+
+interface ZapState {
+  sending: boolean;
+  error?: string;
+  zap: (
+    lnurl: string,
+    amount: number,
+    recipientPubkey: string
+  ) => Promise<void>;
+}
+
+export const useZapStore = create<ZapState>((set) => ({
+  sending: false,
+  error: undefined,
+  async zap(lnurl, amount, recipientPubkey) {
+    set({ sending: true, error: undefined });
+    try {
+      const { invoice } = await fetchInvoice(lnurl, amount);
+      const event: UnsignedEvent = {
+        pubkey: '',
+        kind: 9735,
+        created_at: Math.floor(Date.now() / 1000),
+        tags: [
+          ['p', recipientPubkey],
+          ['bolt11', invoice],
+          ['amount', String(amount * 1000)],
+        ],
+        content: '',
+      };
+      const signed: Event = await NostrService.publish(event);
+      const res = await sendZap(invoice, signed, lnurl);
+      if (res.status !== 'ok') {
+        throw new Error(String(res.data));
+      }
+    } catch (e) {
+      set({ error: e instanceof Error ? e.message : String(e) });
+    } finally {
+      set({ sending: false });
+    }
+  },
+}));
+
+export default function useZap() {
+  return useZapStore();
+}


### PR DESCRIPTION
## Summary
- add `useZap` hook to request LNURL invoices, publish zap receipts on Nostr, and persist them via lightning service
- cover zap workflow with unit test

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689ab34dbaf48331a5dd7ff46c202ff8