### PR TITLE
feat: track zap status and totals

### DIFF
--- a/src/features/zaps/useZap.test.ts
+++ b/src/features/zaps/useZap.test.ts
@@ -1,32 +1,71 @@
 import { beforeEach, expect, test, vi } from 'vitest';
 import { useZapStore } from './useZap';
 
-vi.mock('../../services/lightning', () => ({
-  fetchInvoice: vi.fn().mockResolvedValue({ invoice: 'lninv', metadata: {} }),
-  sendZap: vi.fn().mockResolvedValue({ status: 'ok' }),
-}));
+vi.mock('../../services/lightning', async () => {
+  const actual = await vi.importActual<typeof import('../../services/lightning')>(
+    '../../services/lightning',
+  );
+  return {
+    ...actual,
+    fetchInvoice: vi
+      .fn()
+      .mockResolvedValue({ invoice: 'lninv', metadata: {} }),
+    sendZap: vi.fn().mockResolvedValue({ status: 'ok' }),
+  };
+});
 
 vi.mock('../../services/nostr', () => ({
   __esModule: true,
   default: { publish: vi.fn().mockResolvedValue({ id: 'event1' }) },
 }));
 
+vi.mock('../../services/storage', () => ({
+  getZapReceipts: vi.fn().mockResolvedValue([
+    {
+      id: 'r1',
+      event: {
+        pubkey: 'pubkey1',
+        kind: 9735,
+        created_at: 0,
+        tags: [
+          ['p', 'pubkey1'],
+          ['amount', '21000'],
+          ['e', 'video1'],
+        ],
+        content: '',
+      },
+      metadata: { creator: 'lnurl1', splits: [] },
+      createdAt: 0,
+    },
+  ]),
+}));
+
 import { fetchInvoice, sendZap } from '../../services/lightning';
 import NostrService from '../../services/nostr';
+import { getZapReceipts } from '../../services/storage';
 
 beforeEach(() => {
-  useZapStore.setState({ sending: false, error: undefined });
+  useZapStore.setState({
+    status: 'idle',
+    error: undefined,
+    totals: { byVideo: {}, byUser: {} },
+  });
   vi.clearAllMocks();
 });
 
-test('zap fetches invoice, publishes event, and sends payment', async () => {
-  const { zap, sending } = useZapStore.getState();
-  expect(sending).toBe(false);
-  await zap('lnurl1', 21, 'pubkey1');
+test('zap fetches invoice, publishes event, sends payment, and aggregates totals', async () => {
+  const { zap, status } = useZapStore.getState();
+  expect(status).toBe('idle');
+  await zap('lnurl1', 21, 'pubkey1', 'video1');
   expect(fetchInvoice).toHaveBeenCalledWith('lnurl1', 21);
   expect(NostrService.publish).toHaveBeenCalled();
   expect(sendZap).toHaveBeenCalledWith('lninv', { id: 'event1' }, 'lnurl1');
-  expect(useZapStore.getState().sending).toBe(false);
+  expect(getZapReceipts).toHaveBeenCalled();
+  expect(useZapStore.getState().status).toBe('success');
+  expect(useZapStore.getState().totals.byVideo.video1).toBe(21);
+  expect(useZapStore.getState().totals.byUser.lnurl1).toBe(21);
+  useZapStore.getState().reset();
+  expect(useZapStore.getState().status).toBe('idle');
   expect(useZapStore.getState().error).toBeUndefined();
 });
 

--- a/src/features/zaps/useZap.ts
+++ b/src/features/zaps/useZap.ts
@@ -1,34 +1,71 @@
 import { create } from 'zustand';
 import type { UnsignedEvent, Event } from 'nostr-tools';
 import NostrService from '../../services/nostr';
-import { fetchInvoice, sendZap } from '../../services/lightning';
+import {
+  fetchInvoice,
+  sendZap,
+  parseZapEvent,
+} from '../../services/lightning';
+import { getZapReceipts } from '../../services/storage';
+
+interface ZapTotals {
+  byVideo: Record<string, number>;
+  byUser: Record<string, number>;
+}
 
 interface ZapState {
-  sending: boolean;
+  status: 'idle' | 'pending' | 'success' | 'error';
   error?: string;
+  totals: ZapTotals;
   zap: (
     lnurl: string,
     amount: number,
-    recipientPubkey: string
+    recipientPubkey: string,
+    videoId?: string,
   ) => Promise<void>;
+  loadTotals: () => Promise<void>;
+  reset: () => void;
 }
 
-export const useZapStore = create<ZapState>((set) => ({
-  sending: false,
+function aggregate(receipts: Awaited<ReturnType<typeof getZapReceipts>>): ZapTotals {
+  const totals: ZapTotals = { byVideo: {}, byUser: {} };
+  for (const r of receipts) {
+    const { amount } = parseZapEvent(r.event);
+    const videoTag = r.event.tags.find((t) => t[0] === 'e');
+    if (videoTag) {
+      totals.byVideo[videoTag[1]] = (totals.byVideo[videoTag[1]] || 0) + amount;
+    }
+    const user = r.metadata.creator;
+    totals.byUser[user] = (totals.byUser[user] || 0) + amount;
+  }
+  return totals;
+}
+
+export const useZapStore = create<ZapState>((set, get) => ({
+  status: 'idle',
   error: undefined,
-  async zap(lnurl, amount, recipientPubkey) {
-    set({ sending: true, error: undefined });
+  totals: { byVideo: {}, byUser: {} },
+  async loadTotals() {
+    const receipts = await getZapReceipts();
+    set({ totals: aggregate(receipts) });
+  },
+  async zap(lnurl, amount, recipientPubkey, videoId) {
+    set({ status: 'pending', error: undefined });
     try {
       const { invoice } = await fetchInvoice(lnurl, amount);
+      const tags: string[][] = [
+        ['p', recipientPubkey],
+        ['bolt11', invoice],
+        ['amount', String(amount * 1000)],
+      ];
+      if (videoId) {
+        tags.push(['e', videoId]);
+      }
       const event: UnsignedEvent = {
         pubkey: '',
         kind: 9735,
         created_at: Math.floor(Date.now() / 1000),
-        tags: [
-          ['p', recipientPubkey],
-          ['bolt11', invoice],
-          ['amount', String(amount * 1000)],
-        ],
+        tags,
         content: '',
       };
       const signed: Event = await NostrService.publish(event);
@@ -36,11 +73,14 @@ export const useZapStore = create<ZapState>((set) => ({
       if (res.status !== 'ok') {
         throw new Error(String(res.data));
       }
+      await get().loadTotals();
+      set({ status: 'success' });
     } catch (e) {
-      set({ error: e instanceof Error ? e.message : String(e) });
-    } finally {
-      set({ sending: false });
+      set({ status: 'error', error: e instanceof Error ? e.message : String(e) });
     }
+  },
+  reset() {
+    set({ status: 'idle', error: undefined });
   },
 }));
 


### PR DESCRIPTION
## Summary
- manage zap lifecycle status in Zustand with reset
- aggregate stored zap receipts to compute totals per video and user
- extend tests for zap totals

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689ab6a89878833192e3f51eecba0558