### PR TITLE
feat(upload): queue failed video uploads

### DIFF
--- a/src/features/upload/useUploadVideo.test.ts
+++ b/src/features/upload/useUploadVideo.test.ts
@@ -5,6 +5,13 @@ import useUploadVideo, {
   MAX_VIDEO_DURATION,
   SUPPORTED_VIDEO_TYPES
 } from './useUploadVideo';
+import NostrService from '../../services/nostr';
+import { queueUpload } from '../../services/storage';
+
+vi.mock('../../services/nostr', () => ({
+  default: { publish: vi.fn(), verify: vi.fn() }
+}));
+vi.mock('../../services/storage', () => ({ queueUpload: vi.fn() }));
 
 describe('useUploadVideo', () => {
   beforeEach(() => {
@@ -124,6 +131,87 @@ describe('useUploadVideo', () => {
     act(() => result.current.selectFile(file));
     await waitFor(() => expect(result.current.error).toBe('Video too long'));
     expect(result.current.previewUrl).toBeUndefined();
+  });
+
+  test('queues failed uploads for background sync', async () => {
+    const file = new File(['a'], 'a.mp4', { type: SUPPORTED_VIDEO_TYPES[0] });
+    const mockVideo = {
+      preload: '',
+      src: '',
+      onloadedmetadata: null as (() => void) | null,
+      videoWidth: 720,
+      videoHeight: 1280,
+      duration: 5
+    } as unknown as HTMLVideoElement;
+    const realCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'video') {
+        setTimeout(
+          () => mockVideo.onloadedmetadata?.(new Event('loadedmetadata')),
+          0
+        );
+        return mockVideo;
+      }
+      return realCreateElement(tag);
+    });
+    (global as any).fetch = vi.fn().mockRejectedValue(new Error('offline'));
+
+    const { result } = renderHook(() => useUploadVideo());
+    act(() => result.current.selectFile(file));
+    await waitFor(() => expect(result.current.metadata).toBeDefined());
+    await act(async () => {
+      await result.current.upload('creator', 'caption');
+    });
+    expect(queueUpload).toHaveBeenCalledWith(
+      expect.objectContaining({ creator: 'creator', caption: 'caption' })
+    );
+    expect(NostrService.publish).not.toHaveBeenCalled();
+  });
+
+  test('publishes metadata after successful upload', async () => {
+    const file = new File(['a'], 'a.mp4', { type: SUPPORTED_VIDEO_TYPES[0] });
+    const mockVideo = {
+      preload: '',
+      src: '',
+      onloadedmetadata: null as (() => void) | null,
+      videoWidth: 720,
+      videoHeight: 1280,
+      duration: 5
+    } as unknown as HTMLVideoElement;
+    const realCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      if (tag === 'video') {
+        setTimeout(
+          () => mockVideo.onloadedmetadata?.(new Event('loadedmetadata')),
+          0
+        );
+        return mockVideo;
+      }
+      return realCreateElement(tag);
+    });
+    (global as any).fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: 'https://cdn.test/a.mp4' })
+    });
+    (NostrService.publish as any).mockResolvedValue({
+      id: '1',
+      kind: 1,
+      pubkey: 'pk',
+      created_at: 0,
+      sig: 'sig',
+      tags: [],
+      content: 'https://cdn.test/a.mp4'
+    });
+    (NostrService.verify as any).mockReturnValue(true);
+
+    const { result } = renderHook(() => useUploadVideo());
+    act(() => result.current.selectFile(file));
+    await waitFor(() => expect(result.current.metadata).toBeDefined());
+    await act(async () => {
+      await result.current.upload('creator', 'caption');
+    });
+    expect(NostrService.publish).toHaveBeenCalled();
+    expect(queueUpload).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/storage.test.ts
+++ b/src/services/storage.test.ts
@@ -1,0 +1,78 @@
+import { describe, test, expect, vi } from 'vitest';
+
+vi.mock('dexie', () => {
+  class Table {
+    private store = new Map<string, any>();
+    async put(obj: any) {
+      this.store.set(obj.id, obj);
+    }
+    orderBy() {
+      const entries = this.store;
+      return {
+        first: async () => {
+          const firstKey = [...entries.keys()].sort()[0];
+          return firstKey ? entries.get(firstKey) : undefined;
+        }
+      } as any;
+    }
+    async delete(id: string) {
+      this.store.delete(id);
+    }
+  }
+  class DexieMock {
+    videos = new Table();
+    metadata = new Table();
+    pendingUploads = new Table();
+    zapReceipts = new Table();
+    version() {
+      return { stores: () => ({}) } as any;
+    }
+    transaction(_: any, __: any, fn: any) {
+      return fn();
+    }
+  }
+  return { default: DexieMock, Table };
+});
+
+vi.mock('./nostr', () => ({
+  default: { publish: vi.fn(), verify: vi.fn() }
+}));
+
+import * as storage from './storage';
+import NostrService from './nostr';
+
+describe('processPendingUploads', () => {
+  test('retries queued uploads and publishes metadata', async () => {
+    const file = new Blob(['a'], { type: 'video/mp4' });
+    const pending = {
+      id: '1',
+      endpoint: '/api/upload',
+      file,
+      creator: 'alice',
+      caption: 'hello'
+    };
+    await storage.queueUpload(pending as any);
+    (global as any).fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: 'https://cdn.test/a.mp4' })
+    });
+    (NostrService.publish as any).mockResolvedValue({
+      id: '1',
+      kind: 1,
+      pubkey: 'pk',
+      created_at: 0,
+      sig: 'sig',
+      tags: [],
+      content: 'https://cdn.test/a.mp4'
+    });
+    (NostrService.verify as any).mockReturnValue(true);
+
+    await storage.processPendingUploads();
+
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/upload',
+      expect.objectContaining({ method: 'POST', body: file })
+    );
+    expect(NostrService.publish).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- include video metadata when queuing failed uploads
- retry queued uploads on reconnect and publish Nostr events
- add tests covering offline upload retry flow

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689ae938485483318aa4b9a3838daaa2