### PR TITLE
feat: add comment hook

### DIFF
--- a/src/features/comments/useComments.test.ts
+++ b/src/features/comments/useComments.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, afterEach, expect, test, vi } from 'vitest';
+import type { Event } from 'nostr-tools';
+import NostrService from '../../services/nostr';
+import { useCommentsStore } from './useComments';
+
+const rootId = 'root';
+
+const top: Event = {
+  id: 'c1',
+  kind: 1,
+  pubkey: 'pk',
+  created_at: 2,
+  sig: 'sig',
+  tags: [['e', rootId, '', 'root']],
+  content: 'top',
+};
+
+const reply: Event = {
+  id: 'c2',
+  kind: 1,
+  pubkey: 'pk',
+  created_at: 3,
+  sig: 'sig',
+  tags: [
+    ['e', rootId, '', 'root'],
+    ['e', 'c1', '', 'reply'],
+  ],
+  content: 'reply',
+};
+
+const older: Event = {
+  id: 'c0',
+  kind: 1,
+  pubkey: 'pk',
+  created_at: 1,
+  sig: 'sig',
+  tags: [['e', rootId, '', 'root']],
+  content: 'older',
+};
+
+beforeEach(() => {
+  useCommentsStore.setState({
+    rootId,
+    comments: [],
+    byId: new Map(),
+    cursor: undefined,
+    hasMore: true,
+    loading: false,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('loadComments builds threaded structure', async () => {
+  vi.spyOn(NostrService, 'query').mockResolvedValue([top, reply, older]);
+  await useCommentsStore.getState().loadComments();
+  const state = useCommentsStore.getState();
+  expect(state.comments).toHaveLength(2);
+  expect(state.comments[0].event.id).toBe('c0');
+  expect(state.comments[1].event.id).toBe('c1');
+  expect(state.comments[1].replies[0].event.id).toBe('c2');
+  expect(state.cursor).toBe(1);
+  expect(state.hasMore).toBe(false);
+});
+
+test('addComment publishes and adds to store', async () => {
+  vi.spyOn(NostrService, 'publish').mockResolvedValue(top);
+  await useCommentsStore.getState().addComment('top');
+  expect(useCommentsStore.getState().comments[0].event.id).toBe('c1');
+});
+
+test('replyTo attaches reply to parent', async () => {
+  const topNode = { event: top, replies: [] as any[] };
+  useCommentsStore.setState({
+    rootId,
+    comments: [topNode],
+    byId: new Map([[top.id, topNode]]),
+    cursor: 2,
+    hasMore: true,
+    loading: false,
+  });
+  vi.spyOn(NostrService, 'publish').mockResolvedValue(reply);
+  await useCommentsStore.getState().replyTo('c1', 'reply');
+  expect(useCommentsStore.getState().comments[0].replies[0].event.id).toBe('c2');
+});
+
+test('loadComments stops when no more events', async () => {
+  const spy = vi
+    .spyOn(NostrService, 'query')
+    .mockResolvedValueOnce([top])
+    .mockResolvedValue([]);
+  await useCommentsStore.getState().loadComments();
+  await useCommentsStore.getState().loadComments();
+  expect(spy).toHaveBeenCalledTimes(1);
+});
+

--- a/src/features/comments/useComments.ts
+++ b/src/features/comments/useComments.ts
@@ -1,0 +1,144 @@
+import { create } from 'zustand';
+import { useEffect } from 'react';
+import type { Event, Filter, UnsignedEvent } from 'nostr-tools';
+import NostrService from '../../services/nostr';
+
+/**
+ * Comment node representing an event with nested replies.
+ */
+export interface CommentNode {
+  event: Event;
+  replies: CommentNode[];
+}
+
+interface CommentsState {
+  rootId?: string;
+  comments: CommentNode[];
+  byId: Map<string, CommentNode>;
+  cursor?: number;
+  hasMore: boolean;
+  loading: boolean;
+  setRoot: (id: string) => Promise<void>;
+  loadComments: () => Promise<void>;
+  addComment: (content: string) => Promise<Event>;
+  replyTo: (parentId: string, content: string) => Promise<Event>;
+}
+
+let activeUnsub: (() => void) | undefined;
+
+function findParentId(event: Event): string | undefined {
+  const replyTag = event.tags.find((t) => t[0] === 'e' && t[3] === 'reply');
+  return replyTag?.[1];
+}
+
+function integrateEvent(state: CommentsState, event: Event): CommentsState {
+  if (state.byId.has(event.id)) return state;
+  const node: CommentNode = { event, replies: [] };
+  state.byId.set(event.id, node);
+  const parentId = findParentId(event);
+  if (parentId && state.byId.has(parentId)) {
+    state.byId.get(parentId)!.replies.push(node);
+  } else {
+    state.comments.push(node);
+    state.comments.sort((a, b) => a.event.created_at - b.event.created_at);
+  }
+  state.cursor =
+    state.cursor === undefined
+      ? event.created_at
+      : Math.min(state.cursor, event.created_at);
+  return state;
+}
+
+export const useCommentsStore = create<CommentsState>((set, get) => ({
+  rootId: undefined,
+  comments: [],
+  byId: new Map(),
+  cursor: undefined,
+  hasMore: true,
+  loading: false,
+  async setRoot(id: string) {
+    if (get().rootId === id) return;
+    activeUnsub?.();
+    set({
+      rootId: id,
+      comments: [],
+      byId: new Map(),
+      cursor: undefined,
+      hasMore: true,
+      loading: false,
+    });
+    if (!id) return;
+    const since = Math.floor(Date.now() / 1000);
+    activeUnsub = await NostrService.subscribe(
+      [{ kinds: [1], '#e': [id], since } as Filter],
+      {
+        onEvent: (e) => {
+          set((s) => integrateEvent({ ...s }, e));
+        },
+      }
+    );
+  },
+  async loadComments() {
+    const { rootId, cursor, hasMore, loading } = get();
+    if (!rootId || !hasMore || loading) return;
+    set({ loading: true });
+    const filter: Filter = { kinds: [1], '#e': [rootId], limit: 20 };
+    if (cursor) filter.until = cursor - 1;
+    try {
+      const events = await NostrService.query([filter]);
+      events.sort((a, b) => a.created_at - b.created_at);
+      set((state) => {
+        events.forEach((e) => integrateEvent(state, e));
+        if (events.length < 20) state.hasMore = false;
+        return { ...state };
+      });
+    } finally {
+      set({ loading: false });
+    }
+  },
+  async addComment(content: string) {
+    const { rootId } = get();
+    if (!rootId) throw new Error('no root');
+    const unsigned: UnsignedEvent = {
+      kind: 1,
+      content,
+      tags: [['e', rootId, '', 'root']],
+      created_at: Math.floor(Date.now() / 1000),
+      pubkey: '',
+    };
+    const event = await NostrService.publish(unsigned);
+    set((s) => integrateEvent({ ...s }, event));
+    return event;
+  },
+  async replyTo(parentId: string, content: string) {
+    const { rootId } = get();
+    if (!rootId) throw new Error('no root');
+    const unsigned: UnsignedEvent = {
+      kind: 1,
+      content,
+      tags: [
+        ['e', rootId, '', 'root'],
+        ['e', parentId, '', 'reply'],
+      ],
+      created_at: Math.floor(Date.now() / 1000),
+      pubkey: '',
+    };
+    const event = await NostrService.publish(unsigned);
+    set((s) => integrateEvent({ ...s }, event));
+    return event;
+  },
+}));
+
+export default function useComments(rootId: string) {
+  const { comments, loadComments, addComment, replyTo } = useCommentsStore();
+  const setRoot = useCommentsStore((s) => s.setRoot);
+  useEffect(() => {
+    setRoot(rootId).catch(() => {});
+    return () => {
+      setRoot('').catch(() => {});
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rootId]);
+  return { comments, loadComments, addComment, replyTo };
+}
+


### PR DESCRIPTION
## Summary
- add `useComments` hook for fetching, posting, and subscribing to Nostr comment events
- track comment threads in-memory with helpers for pagination and replies
- throttle comment loading to avoid redundant network requests

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689af9bc7b848331bac832c27cbf8d09