### PR TITLE
feat: add profile and settings hooks

### DIFF
--- a/src/features/profile/useProfile.test.ts
+++ b/src/features/profile/useProfile.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+import { useProfileStore } from './useProfile';
+import { useAuthStore } from '../auth/useAuth';
+import NostrService from '../../services/nostr';
+import { getZapReceipts } from '../../services/storage';
+import { parseZapEvent } from '../../services/lightning';
+
+vi.mock('../../services/nostr', () => ({ default: { query: vi.fn(), publish: vi.fn() } }));
+vi.mock('../../services/storage', () => ({ getZapReceipts: vi.fn() }));
+vi.mock('../../services/lightning', () => ({ parseZapEvent: vi.fn() }));
+
+beforeEach(() => {
+  useProfileStore.setState({ avatar: undefined, bio: undefined, zapTotal: 0 });
+});
+
+test('loadProfile populates metadata and zap totals', async () => {
+  const nostr = vi.mocked(NostrService);
+  nostr.query.mockResolvedValue([
+    { content: JSON.stringify({ picture: 'a', about: 'b' }) } as any,
+  ]);
+  vi.mocked(getZapReceipts).mockResolvedValue([
+    { event: {}, metadata: { creator: 'pub' } } as any,
+  ]);
+  vi.mocked(parseZapEvent).mockReturnValue({ amount: 42 } as any);
+
+  await useProfileStore.getState().loadProfile('pub');
+
+  const state = useProfileStore.getState();
+  expect(state.avatar).toBe('a');
+  expect(state.bio).toBe('b');
+  expect(state.zapTotal).toBe(42);
+});
+
+test('signOut clears state and invokes auth logout', () => {
+  const logout = vi.fn();
+  useAuthStore.setState({ logout } as any);
+  useProfileStore.setState({ avatar: 'x', bio: 'y', zapTotal: 9 });
+
+  useProfileStore.getState().signOut();
+
+  expect(logout).toHaveBeenCalled();
+  expect(useProfileStore.getState()).toMatchObject({
+    avatar: undefined,
+    bio: undefined,
+    zapTotal: 0,
+  });
+});
+
+test('updateProfile publishes metadata event', async () => {
+  useAuthStore.setState({ pubkey: 'pub', logout: vi.fn() } as any);
+  const nostr = vi.mocked(NostrService);
+  nostr.publish.mockResolvedValue({
+    content: JSON.stringify({ picture: 'new', about: 'bio' }),
+  } as any);
+
+  await useProfileStore.getState().updateProfile({ avatar: 'new', bio: 'bio' });
+
+  expect(nostr.publish).toHaveBeenCalled();
+  expect(useProfileStore.getState().avatar).toBe('new');
+});

--- a/src/features/profile/useProfile.ts
+++ b/src/features/profile/useProfile.ts
@@ -1,0 +1,76 @@
+import { create } from 'zustand';
+import type { UnsignedEvent, Event } from 'nostr-tools';
+import NostrService from '../../services/nostr';
+import { getZapReceipts } from '../../services/storage';
+import { parseZapEvent } from '../../services/lightning';
+import { useAuthStore } from '../auth/useAuth';
+
+interface ProfileState {
+  avatar?: string;
+  bio?: string;
+  zapTotal: number;
+  loadProfile: (pubkey: string) => Promise<void>;
+  updateProfile: (data: { avatar?: string; bio?: string }) => Promise<void>;
+  signOut: () => void;
+}
+
+export const useProfileStore = create<ProfileState>((set, get) => ({
+  avatar: undefined,
+  bio: undefined,
+  zapTotal: 0,
+  async loadProfile(pubkey) {
+    // fetch latest metadata event
+    const events = await NostrService.query([
+      { kinds: [0], authors: [pubkey], limit: 1 },
+    ]);
+    let avatar: string | undefined;
+    let bio: string | undefined;
+    if (events.length > 0) {
+      try {
+        const content = JSON.parse(events[0].content || '{}');
+        avatar = content.picture;
+        bio = content.about;
+      } catch {
+        // ignore malformed metadata
+      }
+    }
+    // aggregate zap totals from recent receipts
+    const receipts = await getZapReceipts();
+    let total = 0;
+    for (const r of receipts) {
+      if (r.metadata.creator === pubkey) {
+        total += parseZapEvent(r.event).amount;
+      }
+    }
+    set({ avatar, bio, zapTotal: total });
+  },
+  async updateProfile(data) {
+    const { pubkey } = useAuthStore.getState();
+    if (!pubkey) throw new Error('not logged in');
+    const current = get();
+    const content = JSON.stringify({
+      picture: data.avatar ?? current.avatar,
+      about: data.bio ?? current.bio,
+    });
+    const event: UnsignedEvent = {
+      pubkey: '',
+      kind: 0,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [],
+      content,
+    };
+    const signed: Event = await NostrService.publish(event);
+    set({
+      avatar: JSON.parse(signed.content).picture,
+      bio: JSON.parse(signed.content).about,
+    });
+  },
+  signOut() {
+    useAuthStore.getState().logout();
+    set({ avatar: undefined, bio: undefined, zapTotal: 0 });
+  },
+}));
+
+export default function useProfile() {
+  return useProfileStore();
+}

--- a/src/features/settings/useSettings.test.ts
+++ b/src/features/settings/useSettings.test.ts
@@ -1,0 +1,17 @@
+import { beforeEach, expect, test } from 'vitest';
+import { useSettingsStore } from './useSettings';
+
+beforeEach(() => {
+  useSettingsStore.setState({ theme: 'light', autoplay: true });
+  localStorage.clear();
+});
+
+test('updates and persists preferences', () => {
+  const { setTheme, setAutoplay } = useSettingsStore.getState();
+  setTheme('dark');
+  setAutoplay(false);
+  expect(useSettingsStore.getState()).toMatchObject({
+    theme: 'dark',
+    autoplay: false,
+  });
+});

--- a/src/features/settings/useSettings.ts
+++ b/src/features/settings/useSettings.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type Theme = 'light' | 'dark';
+
+interface SettingsState {
+  theme: Theme;
+  autoplay: boolean;
+  setTheme: (theme: Theme) => void;
+  setAutoplay: (autoplay: boolean) => void;
+}
+
+export const useSettingsStore = create<SettingsState>()(
+  persist(
+    (set) => ({
+      theme: 'light',
+      autoplay: true,
+      setTheme: (theme) => set({ theme }),
+      setAutoplay: (autoplay) => set({ autoplay }),
+    }),
+    { name: 'settings' }
+  )
+);
+
+export default function useSettings() {
+  return useSettingsStore();
+}


### PR DESCRIPTION
## Summary
- add profile hook to load/update metadata and handle sign-out
- scaffold settings hook with persisted preferences

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689afc3c966c8331aac4b8e13a9276a5