### PR TITLE
feat(social): add reactions and follows hooks

### DIFF
--- a/src/features/social/useFollows.test.ts
+++ b/src/features/social/useFollows.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+import type { Event } from 'nostr-tools';
+import NostrService from '../../services/nostr';
+import { useFollowsStore } from './useFollows';
+
+let publishMock: any;
+
+beforeEach(() => {
+  useFollowsStore.setState({ following: new Set() });
+  publishMock?.mockRestore();
+  publishMock = vi
+    .spyOn(NostrService, 'publish')
+    .mockResolvedValue({} as Event);
+});
+
+test('follow adds pubkey and publishes contact list', async () => {
+  await useFollowsStore.getState().follow('pk1');
+  expect(useFollowsStore.getState().following.has('pk1')).toBe(true);
+  expect(publishMock).toHaveBeenCalledWith(
+    expect.objectContaining({ tags: [['p', 'pk1']] })
+  );
+});
+
+test('unfollow removes pubkey and publishes contact list', async () => {
+  useFollowsStore.setState({ following: new Set(['pk1']) });
+  await useFollowsStore.getState().unfollow('pk1');
+  expect(useFollowsStore.getState().following.has('pk1')).toBe(false);
+  expect(publishMock).toHaveBeenCalledWith(expect.objectContaining({ tags: [] }));
+});
+

--- a/src/features/social/useFollows.ts
+++ b/src/features/social/useFollows.ts
@@ -1,0 +1,43 @@
+import { create } from 'zustand';
+import type { UnsignedEvent } from 'nostr-tools';
+import NostrService from '../../services/nostr';
+
+interface FollowsState {
+  following: Set<string>;
+  follow: (pubkey: string) => Promise<void>;
+  unfollow: (pubkey: string) => Promise<void>;
+}
+
+async function publishContacts(following: Set<string>) {
+  const unsigned: UnsignedEvent = {
+    kind: 3,
+    content: '',
+    tags: [...following].map((pk) => ['p', pk]),
+    created_at: Math.floor(Date.now() / 1000),
+    pubkey: '',
+  };
+  await NostrService.publish(unsigned);
+}
+
+export const useFollowsStore = create<FollowsState>((set, get) => ({
+  following: new Set<string>(),
+  async follow(pubkey) {
+    if (get().following.has(pubkey)) return;
+    const next = new Set(get().following);
+    next.add(pubkey);
+    await publishContacts(next);
+    set({ following: next });
+  },
+  async unfollow(pubkey) {
+    if (!get().following.has(pubkey)) return;
+    const next = new Set(get().following);
+    next.delete(pubkey);
+    await publishContacts(next);
+    set({ following: next });
+  },
+}));
+
+export default function useFollows() {
+  return useFollowsStore();
+}
+

--- a/src/features/social/useReactions.test.ts
+++ b/src/features/social/useReactions.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+import type { Event } from 'nostr-tools';
+import NostrService from '../../services/nostr';
+import { useReactionsStore } from './useReactions';
+
+let publishMock: any;
+
+beforeEach(() => {
+  useReactionsStore.setState({ liked: new Set() });
+  publishMock?.mockRestore();
+  publishMock = vi
+    .spyOn(NostrService, 'publish')
+    .mockResolvedValue({} as Event);
+});
+
+test('toggleLike publishes like and unlike events', async () => {
+  await useReactionsStore.getState().toggleLike('e1', 'p1');
+  expect(publishMock).toHaveBeenCalledWith(
+    expect.objectContaining({ content: '+' })
+  );
+  expect(useReactionsStore.getState().liked.has('e1')).toBe(true);
+
+  await useReactionsStore.getState().toggleLike('e1', 'p1');
+  expect(publishMock).toHaveBeenCalledWith(
+    expect.objectContaining({ content: '-' })
+  );
+  expect(useReactionsStore.getState().liked.has('e1')).toBe(false);
+  expect(publishMock).toHaveBeenCalledTimes(2);
+});
+

--- a/src/features/social/useReactions.ts
+++ b/src/features/social/useReactions.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+import type { UnsignedEvent } from 'nostr-tools';
+import NostrService from '../../services/nostr';
+
+interface ReactionsState {
+  liked: Set<string>;
+  toggleLike: (eventId: string, pubkey: string) => Promise<void>;
+}
+
+export const useReactionsStore = create<ReactionsState>((set, get) => ({
+  liked: new Set<string>(),
+  async toggleLike(eventId, pubkey) {
+    const liked = new Set(get().liked);
+    const hasLiked = liked.has(eventId);
+    const content = hasLiked ? '-' : '+';
+    const unsigned: UnsignedEvent = {
+      kind: 7,
+      content,
+      tags: [
+        ['e', eventId],
+        ['p', pubkey],
+      ],
+      created_at: Math.floor(Date.now() / 1000),
+      pubkey: '',
+    };
+    await NostrService.publish(unsigned);
+    if (hasLiked) {
+      liked.delete(eventId);
+    } else {
+      liked.add(eventId);
+    }
+    set({ liked });
+  },
+}));
+
+export default function useReactions() {
+  return useReactionsStore();
+}
+


### PR DESCRIPTION
## Summary
- add `useReactions` hook with `toggleLike`
- add `useFollows` hook with `follow` and `unfollow`
- test social hooks for state updates and event publishing

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689b011da63883319321306a45127127