### PR TITLE
feat(comments): expose cleanup in comments hook

### DIFF
--- a/src/features/comments/useComments.ts
+++ b/src/features/comments/useComments.ts
@@ -132,13 +132,14 @@ export const useCommentsStore = create<CommentsState>((set, get) => ({
 export default function useComments(rootId: string) {
   const { comments, loadComments, addComment, replyTo } = useCommentsStore();
   const setRoot = useCommentsStore((s) => s.setRoot);
+  const cleanup = () => {
+    setRoot('').catch(() => {});
+  };
   useEffect(() => {
     setRoot(rootId).catch(() => {});
-    return () => {
-      setRoot('').catch(() => {});
-    };
+    return cleanup;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [rootId]);
-  return { comments, loadComments, addComment, replyTo };
+  return { comments, loadComments, addComment, replyTo, cleanup };
 }
 


### PR DESCRIPTION
## Summary
- add a cleanup handler to `useComments` so callers can release Nostr subscriptions

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689b06d4daa083318f0542c6e706da5c