### PR TITLE
docs: describe profile and settings store fields

### DIFF
--- a/src/features/profile/useProfile.ts
+++ b/src/features/profile/useProfile.ts
@@ -5,12 +5,21 @@ import { getZapReceipts } from '../../services/storage';
 import { parseZapEvent } from '../../services/lightning';
 import { useAuthStore } from '../auth/useAuth';
 
-interface ProfileState {
+/**
+ * Shape of the profile store returned by {@link useProfile}.
+ */
+export interface ProfileState {
+  /** Profile image URL */
   avatar?: string;
+  /** Short bio or description */
   bio?: string;
+  /** Sum of received zap amounts */
   zapTotal: number;
+  /** Fetch metadata and zap receipts for a given pubkey */
   loadProfile: (pubkey: string) => Promise<void>;
+  /** Publish updated profile metadata */
   updateProfile: (data: { avatar?: string; bio?: string }) => Promise<void>;
+  /** Clear profile state and sign the user out */
   signOut: () => void;
 }
 
@@ -71,6 +80,11 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
   },
 }));
 
-export default function useProfile() {
+/**
+ * Access the profile store containing metadata and helpers.
+ *
+ * @returns {ProfileState} Current profile state and actions.
+ */
+export default function useProfile(): ProfileState {
   return useProfileStore();
 }

--- a/src/features/settings/useSettings.ts
+++ b/src/features/settings/useSettings.ts
@@ -3,10 +3,17 @@ import { persist } from 'zustand/middleware';
 
 type Theme = 'light' | 'dark';
 
-interface SettingsState {
+/**
+ * Shape of the settings store returned by {@link useSettings}.
+ */
+export interface SettingsState {
+  /** Preferred color theme */
   theme: Theme;
+  /** Whether videos should start playing automatically */
   autoplay: boolean;
+  /** Persist a new theme choice */
   setTheme: (theme: Theme) => void;
+  /** Persist autoplay preference */
   setAutoplay: (autoplay: boolean) => void;
 }
 
@@ -22,6 +29,11 @@ export const useSettingsStore = create<SettingsState>()(
   )
 );
 
-export default function useSettings() {
+/**
+ * Access persisted user preferences for theming and playback.
+ *
+ * @returns {SettingsState} Current settings state and actions.
+ */
+export default function useSettings(): SettingsState {
   return useSettingsStore();
 }


### PR DESCRIPTION
## Summary
- document profile store fields for avatar, bio, and zap totals
- document settings store fields for theme and autoplay persistence

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689b0844337883319655600aeb90df90