### PR TITLE
feat(social): cache reactions and follows with nostr sync

### DIFF
--- a/src/features/social/useFollows.test.ts
+++ b/src/features/social/useFollows.test.ts
@@ -7,6 +7,7 @@ let publishMock: any;
 
 beforeEach(() => {
   useFollowsStore.setState({ following: new Set() });
+  localStorage.clear();
   publishMock?.mockRestore();
   publishMock = vi
     .spyOn(NostrService, 'publish')

--- a/src/features/social/useFollows.ts
+++ b/src/features/social/useFollows.ts
@@ -1,11 +1,15 @@
 import { create } from 'zustand';
-import type { UnsignedEvent } from 'nostr-tools';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { useEffect } from 'react';
+import type { UnsignedEvent, Event } from 'nostr-tools';
 import NostrService from '../../services/nostr';
+import useAuth from '../auth/useAuth';
 
 interface FollowsState {
   following: Set<string>;
   follow: (pubkey: string) => Promise<void>;
   unfollow: (pubkey: string) => Promise<void>;
+  sync: (pubkey: string) => Promise<void>;
 }
 
 async function publishContacts(following: Set<string>) {
@@ -19,25 +23,59 @@ async function publishContacts(following: Set<string>) {
   await NostrService.publish(unsigned);
 }
 
-export const useFollowsStore = create<FollowsState>((set, get) => ({
-  following: new Set<string>(),
-  async follow(pubkey) {
-    if (get().following.has(pubkey)) return;
-    const next = new Set(get().following);
-    next.add(pubkey);
-    await publishContacts(next);
-    set({ following: next });
-  },
-  async unfollow(pubkey) {
-    if (!get().following.has(pubkey)) return;
-    const next = new Set(get().following);
-    next.delete(pubkey);
-    await publishContacts(next);
-    set({ following: next });
-  },
-}));
-
+let unsubscribe: (() => void) | undefined;
+export const useFollowsStore = create<FollowsState>()(
+  persist(
+    (set, get) => ({
+      following: new Set<string>(),
+      async follow(pubkey) {
+        if (get().following.has(pubkey)) return;
+        const next = new Set(get().following);
+        next.add(pubkey);
+        await publishContacts(next);
+        set({ following: next });
+      },
+      async unfollow(pubkey) {
+        if (!get().following.has(pubkey)) return;
+        const next = new Set(get().following);
+        next.delete(pubkey);
+        await publishContacts(next);
+        set({ following: next });
+      },
+      async sync(pubkey) {
+        if (unsubscribe || !pubkey) return;
+        unsubscribe = await NostrService.subscribe(
+          [{ kinds: [3], authors: [pubkey], limit: 1 }],
+          {
+            onEvent(event: Event) {
+              const following = new Set(
+                event.tags.filter((t) => t[0] === 'p').map((t) => t[1])
+              );
+              set({ following });
+            },
+          }
+        );
+      },
+    }),
+    {
+      name: 'follows',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ following: Array.from(state.following) }),
+      merge: (persisted: any, current) => ({
+        ...current,
+        following: new Set(persisted?.following || []),
+      }),
+    }
+  )
+);
 export default function useFollows() {
-  return useFollowsStore();
+  const { pubkey } = useAuth();
+  const store = useFollowsStore();
+  useEffect(() => {
+    if (pubkey) {
+      void store.sync(pubkey);
+    }
+  }, [pubkey, store]);
+  return store;
 }
 

--- a/src/features/social/useReactions.test.ts
+++ b/src/features/social/useReactions.test.ts
@@ -7,6 +7,7 @@ let publishMock: any;
 
 beforeEach(() => {
   useReactionsStore.setState({ liked: new Set() });
+  localStorage.clear();
   publishMock?.mockRestore();
   publishMock = vi
     .spyOn(NostrService, 'publish')

--- a/src/features/social/useReactions.ts
+++ b/src/features/social/useReactions.ts
@@ -1,39 +1,84 @@
 import { create } from 'zustand';
-import type { UnsignedEvent } from 'nostr-tools';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { useEffect } from 'react';
+import type { UnsignedEvent, Event } from 'nostr-tools';
 import NostrService from '../../services/nostr';
+import useAuth from '../auth/useAuth';
 
 interface ReactionsState {
   liked: Set<string>;
   toggleLike: (eventId: string, pubkey: string) => Promise<void>;
+  sync: (pubkey: string) => Promise<void>;
 }
 
-export const useReactionsStore = create<ReactionsState>((set, get) => ({
-  liked: new Set<string>(),
-  async toggleLike(eventId, pubkey) {
-    const liked = new Set(get().liked);
-    const hasLiked = liked.has(eventId);
-    const content = hasLiked ? '-' : '+';
-    const unsigned: UnsignedEvent = {
-      kind: 7,
-      content,
-      tags: [
-        ['e', eventId],
-        ['p', pubkey],
-      ],
-      created_at: Math.floor(Date.now() / 1000),
-      pubkey: '',
-    };
-    await NostrService.publish(unsigned);
-    if (hasLiked) {
-      liked.delete(eventId);
-    } else {
-      liked.add(eventId);
+let unsubscribe: (() => void) | undefined;
+
+export const useReactionsStore = create<ReactionsState>()(
+  persist(
+    (set, get) => ({
+      liked: new Set<string>(),
+      async toggleLike(eventId, pubkey) {
+        const liked = new Set(get().liked);
+        const hasLiked = liked.has(eventId);
+        const content = hasLiked ? '-' : '+';
+        const unsigned: UnsignedEvent = {
+          kind: 7,
+          content,
+          tags: [
+            ['e', eventId],
+            ['p', pubkey],
+          ],
+          created_at: Math.floor(Date.now() / 1000),
+          pubkey: '',
+        };
+        await NostrService.publish(unsigned);
+        if (hasLiked) {
+          liked.delete(eventId);
+        } else {
+          liked.add(eventId);
+        }
+        set({ liked });
+      },
+      async sync(pubkey) {
+        if (unsubscribe || !pubkey) return;
+        unsubscribe = await NostrService.subscribe(
+          [{ kinds: [7], authors: [pubkey] }],
+          {
+            onEvent(event: Event) {
+              const eTag = event.tags.find((t) => t[0] === 'e');
+              if (!eTag) return;
+              const liked = new Set(get().liked);
+              if (event.content === '+') {
+                liked.add(eTag[1]);
+              } else if (event.content === '-') {
+                liked.delete(eTag[1]);
+              }
+              set({ liked });
+            },
+          }
+        );
+      },
+    }),
+    {
+      name: 'reactions',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ liked: Array.from(state.liked) }),
+      merge: (persisted: any, current) => ({
+        ...current,
+        liked: new Set(persisted?.liked || []),
+      }),
     }
-    set({ liked });
-  },
-}));
+  )
+);
 
 export default function useReactions() {
-  return useReactionsStore();
+  const { pubkey } = useAuth();
+  const store = useReactionsStore();
+  useEffect(() => {
+    if (pubkey) {
+      void store.sync(pubkey);
+    }
+  }, [pubkey, store]);
+  return store;
 }
 


### PR DESCRIPTION
## Summary
- persist liked reactions locally using Zustand and localStorage
- subscribe to Nostr reaction events to keep local state in sync
- persist followed contacts and reconcile with Nostr contact list events
- clear reaction and follow persistence between tests

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689b0cb775d0833196f3d5b98455f537