### PR TITLE
feat: add video feed page

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@noble/hashes": "^1.8.0",
     "dexie": "^4.0.11",
+    "framer-motion": "^11",
     "lnurl-pay": "^4.0.0",
     "lodash.debounce": "^4.0.8",
     "next": "^15.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       dexie:
         specifier: ^4.0.11
         version: 4.0.11
+      framer-motion:
+        specifier: ^11
+        version: 11.18.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       lnurl-pay:
         specifier: ^4.0.0
         version: 4.0.0
@@ -2421,6 +2424,20 @@ packages:
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
 
+  framer-motion@11.18.2:
+    resolution: {integrity: sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
     engines: {node: '>=10'}
@@ -3003,6 +3020,12 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  motion-dom@11.18.1:
+    resolution: {integrity: sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==}
+
+  motion-utils@11.18.1:
+    resolution: {integrity: sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -6722,6 +6745,15 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
+  framer-motion@11.18.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      motion-dom: 11.18.1
+      motion-utils: 11.18.1
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+
   fs-extra@9.1.0:
     dependencies:
       at-least-node: 1.0.0
@@ -7343,6 +7375,12 @@ snapshots:
       brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
+
+  motion-dom@11.18.1:
+    dependencies:
+      motion-utils: 11.18.1
+
+  motion-utils@11.18.1: {}
 
   ms@2.1.3: {}
 

--- a/src/pages/feed.tsx
+++ b/src/pages/feed.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { Filter } from 'nostr-tools';
+import { motion } from 'framer-motion';
+import useVideoFeed from '@/features/feed/useVideoFeed';
+import { createPlayer } from '@/services/video';
+
+export default function FeedPage() {
+  const filters = useMemo<Filter[]>(() => [{ kinds: [1] }], []);
+  const { currentVideo, next, prev } = useVideoFeed(filters);
+
+  const videoRef = useRef<HTMLVideoElement>(null!);
+  const { Player, load, play, pause, seek } = useMemo(
+    () => createPlayer(videoRef, { onEnded: next }),
+    [next],
+  );
+  const [playing, setPlaying] = useState(false);
+  const [indicator, setIndicator] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (currentVideo?.content) {
+      load(currentVideo.content);
+      play();
+      setPlaying(true);
+      if (videoRef.current) {
+        videoRef.current.playbackRate = 1;
+      }
+    }
+  }, [currentVideo, load, play]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowDown') next();
+      if (e.key === 'ArrowUp') prev();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [next, prev]);
+
+  const touchStart = useRef({ x: 0, y: 0, time: 0 });
+  const longPress = useRef(false);
+  const longPressTimer = useRef<number | undefined>(undefined);
+  const scrubbing = useRef(false);
+  const scrubStartX = useRef(0);
+  const scrubStartTime = useRef(0);
+
+  useEffect(() => {
+    return () => clearTimeout(longPressTimer.current);
+  }, []);
+
+  const onPointerDown: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    touchStart.current = { x: e.clientX, y: e.clientY, time: Date.now() };
+    longPress.current = false;
+    scrubbing.current = false;
+    longPressTimer.current = window.setTimeout(() => {
+      const rect = videoRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const relY = e.clientY - rect.top;
+      longPress.current = true;
+      if (!playing) {
+        play();
+        setPlaying(true);
+      }
+      videoRef.current.playbackRate = 2;
+      setIndicator('2x');
+      if (relY >= (rect.height * 2) / 3) {
+        scrubbing.current = true;
+        scrubStartX.current = e.clientX;
+        scrubStartTime.current = videoRef.current.currentTime;
+      }
+    }, 500);
+  };
+
+  const onPointerMove: React.PointerEventHandler<HTMLDivElement> = (e) => {
+    if (longPress.current && scrubbing.current) {
+      const deltaX = e.clientX - scrubStartX.current;
+      const seconds = scrubStartTime.current + deltaX * 0.05;
+      seek(Math.max(0, seconds));
+    } else if (!longPress.current) {
+      const dx = e.clientX - touchStart.current.x;
+      const dy = e.clientY - touchStart.current.y;
+      if (Math.abs(dx) > 10 || Math.abs(dy) > 10) {
+        clearTimeout(longPressTimer.current);
+      }
+    }
+  };
+
+  const onPointerUp: React.PointerEventHandler<HTMLDivElement> = () => {
+    clearTimeout(longPressTimer.current);
+    if (longPress.current) {
+      videoRef.current.playbackRate = 1;
+      setIndicator(null);
+      longPress.current = false;
+      scrubbing.current = false;
+      return;
+    }
+    const elapsed = Date.now() - touchStart.current.time;
+    if (elapsed < 200) {
+      if (playing) {
+        pause();
+        setPlaying(false);
+        setIndicator('Paused');
+      } else {
+        play();
+        setPlaying(true);
+        setIndicator('Playing');
+      }
+      window.setTimeout(() => setIndicator(null), 500);
+    }
+  };
+
+  const onPanEnd = (_: any, info: { offset: { y: number } }) => {
+    if (longPress.current) return;
+    if (info.offset.y < -50) {
+      next();
+    } else if (info.offset.y > 50) {
+      prev();
+    }
+  };
+
+  return (
+    <motion.div
+      className="h-screen w-screen bg-black"
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPanEnd={onPanEnd}
+    >
+      {currentVideo ? (
+        <div className="relative h-full w-full">
+          <Player />
+          {indicator && (
+            <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-white text-3xl">
+              {indicator}
+            </div>
+          )}
+        </div>
+      ) : (
+        <p className="flex h-full items-center justify-center text-white">Loading...</p>
+      )}
+    </motion.div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add feed page composing `useVideoFeed` with video player
- support swipe and keyboard navigation between videos
- add tap, long-press, and scrubbing touch gestures for playback control
- leverage framer-motion to handle swipe gestures

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689b13bf9cac8331b20369f7c3399fa1