### PR TITLE
feat: add bolt11 proxy and zap component

### DIFF
--- a/src/components/zap/ZapButton.test.tsx
+++ b/src/components/zap/ZapButton.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ZapButton from './ZapButton';
+import useZap from '../../features/zaps/useZap';
+import { vi, type Mock } from 'vitest';
+
+vi.mock('../../features/zaps/useZap');
+
+const zap = vi.fn();
+const loadTotals = vi.fn();
+
+(useZap as unknown as Mock).mockReturnValue({
+  zap,
+  status: 'idle',
+  totals: { byVideo: {}, byUser: {} },
+  error: undefined,
+  loadTotals,
+});
+
+describe('ZapButton', () => {
+  it('renders status and triggers zap', () => {
+    render(<ZapButton lnurl="ln" recipientPubkey="pub" />);
+    expect(loadTotals).toHaveBeenCalled();
+    expect(screen.getByText(/Status: idle/)).toBeInTheDocument();
+    expect(screen.getByText(/Total: 0/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button'));
+    expect(zap).toHaveBeenCalled();
+  });
+
+  it('shows error message', () => {
+    (useZap as unknown as Mock).mockReturnValueOnce({
+      zap,
+      status: 'error',
+      totals: { byVideo: {}, byUser: {} },
+      error: 'fail',
+      loadTotals,
+    });
+    render(<ZapButton lnurl="ln" recipientPubkey="pub" />);
+    expect(screen.getByRole('alert')).toHaveTextContent('fail');
+  });
+});

--- a/src/components/zap/ZapButton.tsx
+++ b/src/components/zap/ZapButton.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect } from 'react';
+import useZap from '../../features/zaps/useZap';
+
+export interface ZapButtonProps {
+  lnurl: string;
+  recipientPubkey: string;
+  videoId?: string;
+}
+
+/**
+ * Button that triggers the zap flow and displays status and totals.
+ * Side effects are handled within the useZap hook.
+ */
+export default function ZapButton({
+  lnurl,
+  recipientPubkey,
+  videoId,
+}: ZapButtonProps) {
+  const { zap, status, totals, error, loadTotals } = useZap();
+  const amount = 1;
+
+  useEffect(() => {
+    loadTotals().catch(() => {
+      /* ignore load errors */
+    });
+  }, [loadTotals]);
+
+  const total =
+    videoId && totals.byVideo[videoId] !== undefined
+      ? totals.byVideo[videoId]
+      : totals.byUser[recipientPubkey] || 0;
+
+  return (
+    <div className="flex flex-col gap-2 text-sm text-white">
+      <button
+        type="button"
+        onClick={() => zap(lnurl, amount, recipientPubkey, videoId)}
+        disabled={status === 'pending'}
+        className="rounded bg-yellow-400 px-2 py-1 font-medium text-black disabled:opacity-50"
+      >
+        Zap {amount} sats
+      </button>
+      <div>
+        <p>Status: {status}</p>
+        <p>Total: {total}</p>
+        {error && (
+          <p role="alert" className="text-red-500">
+            {error}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/zap/index.ts
+++ b/src/components/zap/index.ts
@@ -1,0 +1,1 @@
+export { default as ZapButton } from './ZapButton';

--- a/src/pages/api/bolt11.ts
+++ b/src/pages/api/bolt11.ts
@@ -1,0 +1,49 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+interface BoltRequest {
+  invoice?: string;
+  nostr?: unknown;
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).end('Method Not Allowed');
+    return;
+  }
+
+  const { invoice, nostr } = req.body as BoltRequest;
+  if (!invoice || typeof invoice !== 'string') {
+    res.status(400).json({ error: 'Missing invoice' });
+    return;
+  }
+
+  const url = process.env.LIGHTNING_PAY_URL;
+  const apiKey = process.env.LIGHTNING_PAY_KEY;
+  if (!url) {
+    res.status(500).json({ error: 'Lightning backend not configured' });
+    return;
+  }
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(apiKey ? { 'X-Api-Key': apiKey } : {}),
+      },
+      body: JSON.stringify({ bolt11: invoice, nostr }),
+    });
+
+    const text = await response.text();
+    res
+      .status(response.ok ? 200 : response.status)
+      .send(text);
+  } catch (e) {
+    res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
+  }
+}
+


### PR DESCRIPTION
## Summary
- add Next.js API route to forward BOLT11 invoices to a configured Lightning backend
- create ZapButton component using `useZap` to send zaps and display status totals and errors
- include unit tests for ZapButton

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689b1e479968833186f6ff17be1d4caa