### PR TITLE
feat: add upload page and background retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ playwright-report
 coverage
 test-results
 tsconfig.tsbuildinfo
+public/uploads
 

--- a/src/pages/api/upload.ts
+++ b/src/pages/api/upload.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createWriteStream, promises as fs } from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import { pipeline } from 'stream/promises';
+
+export const config = {
+  api: {
+    bodyParser: false
+  }
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).end('Method Not Allowed');
+  }
+
+  const ext = (req.headers['content-type']?.split('/')[1] || 'mp4').split(';')[0];
+  const fileName = `${randomUUID()}.${ext}`;
+  const uploadDir = path.join(process.cwd(), 'public', 'uploads');
+  await fs.mkdir(uploadDir, { recursive: true });
+  const filePath = path.join(uploadDir, fileName);
+  const writeStream = createWriteStream(filePath);
+  await pipeline(req, writeStream);
+  const url = `/uploads/${fileName}`;
+  res.status(200).json({ url });
+}

--- a/src/pages/upload.tsx
+++ b/src/pages/upload.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import useUploadVideo from '@/features/upload/useUploadVideo';
+
+export default function UploadPage() {
+  const { selectFile, previewUrl, upload, error, reset, inputProps } = useUploadVideo();
+  const [caption, setCaption] = useState('');
+  const [creator, setCreator] = useState('');
+
+  const handleFile: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+    const file = e.target.files?.[0];
+    selectFile(file);
+  };
+
+  const submit: React.FormEventHandler<HTMLFormElement> = async (e) => {
+    e.preventDefault();
+    await upload(creator, caption);
+    setCaption('');
+    setCreator('');
+    reset();
+  };
+
+  return (
+    <div className="p-4">
+      <form onSubmit={submit} className="flex flex-col gap-4">
+        <input
+          type="text"
+          placeholder="Creator pubkey"
+          className="border p-2"
+          value={creator}
+          onChange={(e) => setCreator(e.target.value)}
+        />
+        <input
+          type="text"
+          placeholder="Caption"
+          className="border p-2"
+          value={caption}
+          onChange={(e) => setCaption(e.target.value)}
+        />
+        <input type="file" className="border p-2" onChange={handleFile} {...inputProps} />
+        {previewUrl && (
+          <video src={previewUrl} controls className="w-full" />
+        )}
+        {error && <p className="text-red-500">{error}</p>}
+        <button type="submit" className="bg-blue-500 text-white p-2" disabled={!previewUrl}>
+          Upload
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,0 +1,6 @@
+import { precache, registerUploadRoute } from '../src/services/storage';
+
+declare let self: ServiceWorkerGlobalScope;
+
+precache(self.__WB_MANIFEST);
+registerUploadRoute();


### PR DESCRIPTION
## Summary
- add upload page that previews and submits videos with `useUploadVideo`
- handle video uploads via API returning storage URLs
- register background upload retry route in service worker

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689b22a0770c8331ad5d2d75a77fc1a0