### PR TITLE
feat: add workbox service worker

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,10 @@
 import withPWAInit from 'next-pwa';
 
-const withPWA = withPWAInit({ dest: 'public' });
+const withPWA = withPWAInit({
+  dest: 'public',
+  register: true,
+  swSrc: 'worker/index.ts'
+});
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import type { AppProps } from 'next/app';
 import '@/styles/globals.css';
+import 'next-pwa/register';
 
 export default function App({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />;

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,6 +1,14 @@
-import { precache, registerUploadRoute } from '../src/services/storage';
+import { registerUploadRoute } from '../src/services/storage';
+import { precacheAndRoute } from 'workbox-precaching';
 
-declare let self: ServiceWorkerGlobalScope;
+declare const self: ServiceWorkerGlobalScope & {
+  __WB_MANIFEST: Array<{ url: string; revision: string | null }>;
+};
 
-precache(self.__WB_MANIFEST);
+precacheAndRoute([
+  ...self.__WB_MANIFEST,
+  { url: '/', revision: null },
+  { url: '/favicon.ico', revision: null }
+]);
+
 registerUploadRoute();


### PR DESCRIPTION
## Summary
- implement Workbox service worker to precache critical assets and handle upload route
- configure next-pwa to compile worker and auto-register at startup

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689b24128c088331a45a94f150ddd9f0