### PR TITLE
feat: add authentication panel with remote signer support

### DIFF
--- a/src/components/auth/AuthPanel.test.ts
+++ b/src/components/auth/AuthPanel.test.ts
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AuthPanel from './AuthPanel';
+import useAuth from '../../features/auth/useAuth';
+import useRemoteSigner from '../../features/auth/useRemoteSigner';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../features/auth/useAuth');
+vi.mock('../../features/auth/useRemoteSigner');
+
+const mockUseAuth = useAuth as any;
+const mockUseRemoteSigner = useRemoteSigner as any;
+
+describe('AuthPanel', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReset();
+    mockUseRemoteSigner.mockReset();
+    // eslint-disable-next-line
+    delete (globalThis as any).nostr;
+  });
+
+  it('shows fallback when no extension', () => {
+    mockUseAuth.mockReturnValue({
+      pubkey: undefined,
+      method: undefined,
+      login: vi.fn(),
+      logout: vi.fn(),
+    });
+    mockUseRemoteSigner.mockReturnValue({
+      connectRemote: vi.fn(),
+      disconnect: vi.fn(),
+    });
+
+    render(React.createElement(AuthPanel));
+    expect(
+      screen.getByText(/nostr extension not detected/i)
+    ).toBeInTheDocument();
+  });
+
+  it('calls login on connect click', () => {
+    const login = vi.fn();
+    mockUseAuth.mockReturnValue({
+      pubkey: undefined,
+      method: undefined,
+      login,
+      logout: vi.fn(),
+    });
+    mockUseRemoteSigner.mockReturnValue({
+      connectRemote: vi.fn(),
+      disconnect: vi.fn(),
+    });
+
+    render(React.createElement(AuthPanel));
+    fireEvent.click(screen.getByRole('button', { name: /^connect$/i }));
+    expect(login).toHaveBeenCalled();
+  });
+
+  it('renders status when connected', () => {
+    mockUseAuth.mockReturnValue({
+      pubkey: 'abcdef123456',
+      method: 'nip07',
+      login: vi.fn(),
+      logout: vi.fn(),
+    });
+    mockUseRemoteSigner.mockReturnValue({
+      connectRemote: vi.fn(),
+      disconnect: vi.fn(),
+    });
+
+    render(React.createElement(AuthPanel));
+    expect(screen.getByTestId('status').textContent).toMatch(/Connected/);
+  });
+
+  it('calls connectRemote with input', () => {
+    const connectRemote = vi.fn();
+    mockUseAuth.mockReturnValue({
+      pubkey: undefined,
+      method: undefined,
+      login: vi.fn(),
+      logout: vi.fn(),
+    });
+    mockUseRemoteSigner.mockReturnValue({
+      connectRemote,
+      disconnect: vi.fn(),
+    });
+
+    render(React.createElement(AuthPanel));
+    const input = screen.getByPlaceholderText('bunker://...');
+    fireEvent.change(input, { target: { value: 'bunker://abc' } });
+    fireEvent.click(screen.getByRole('button', { name: /connect remote/i }));
+    expect(connectRemote).toHaveBeenCalledWith('bunker://abc');
+  });
+});
+

--- a/src/components/auth/AuthPanel.tsx
+++ b/src/components/auth/AuthPanel.tsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useState } from 'react';
+import useAuth from '../../features/auth/useAuth';
+import useRemoteSigner from '../../features/auth/useRemoteSigner';
+
+/**
+ * Authentication panel allowing users to connect via NIP-07 extension
+ * or a remote NIP-46 signer. Displays current status and
+ * provides fallback messaging when no extension is available.
+ */
+export default function AuthPanel() {
+  const { pubkey, method, login, logout } = useAuth();
+  const { connectRemote, disconnect } = useRemoteSigner();
+
+  const [input, setInput] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [hasExtension, setHasExtension] = useState(true);
+
+  useEffect(() => {
+    const nostr = (globalThis as any).nostr;
+    if (!nostr || typeof nostr.getPublicKey !== 'function') {
+      setHasExtension(false);
+    }
+  }, []);
+
+  async function handleConnect() {
+    try {
+      setError(null);
+      await login();
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  }
+
+  async function handleRemoteConnect() {
+    try {
+      setError(null);
+      await connectRemote(input);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  }
+
+  async function handleDisconnect() {
+    setError(null);
+    if (method === 'nip46') {
+      await disconnect();
+    } else {
+      logout();
+    }
+  }
+
+  const status = pubkey
+    ? `Connected via ${method ?? 'unknown'} (${pubkey.slice(0, 8)}...)`
+    : 'Not connected';
+
+  return (
+    <div className="flex flex-col gap-2 p-4 text-sm text-white">
+      <span data-testid="status">{status}</span>
+      {error && (
+        <div role="alert" className="text-red-500">
+          {error}
+        </div>
+      )}
+      {!pubkey && (
+        <div className="flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={handleConnect}
+            className="rounded bg-blue-500 px-2 py-1"
+          >
+            Connect
+          </button>
+          {!hasExtension && (
+            <span className="text-yellow-400">
+              Nostr extension not detected. You can use a remote signer.
+            </span>
+          )}
+          <div className="flex flex-row gap-2">
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="bunker://..."
+              className="flex-grow rounded bg-gray-800 p-1"
+            />
+            <button
+              type="button"
+              onClick={handleRemoteConnect}
+              className="rounded bg-green-600 px-2 py-1"
+            >
+              Connect Remote
+            </button>
+          </div>
+        </div>
+      )}
+      {pubkey && (
+        <button
+          type="button"
+          onClick={handleDisconnect}
+          className="mt-2 rounded bg-red-500 px-2 py-1"
+        >
+          Disconnect
+        </button>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/auth/index.ts
+++ b/src/components/auth/index.ts
@@ -1,0 +1,1 @@
+export { default as AuthPanel } from './AuthPanel';


### PR DESCRIPTION
## Summary
- add `AuthPanel` component to connect/disconnect using `useAuth` and `useRemoteSigner`
- show signer status and fallback message when no NIP-07 extension is detected
- unit tests for connect flows and remote signer input

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689b25403f3883318179de1ca60976a2