### PR TITLE
Remove manual next-pwa registration to avoid require cycle

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,5 @@
 import type { AppProps } from 'next/app';
 import '@/styles/globals.css';
-import 'next-pwa/register';
 
 export default function App({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />;


### PR DESCRIPTION
## Summary
- remove `next-pwa/register` import from `_app.tsx` and rely on plugin configuration for service worker registration

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm build` *(fails: Cannot find module `workbox-background-sync/lib/QueueStore`)*

------
https://chatgpt.com/codex/tasks/task_e_689b2cf9b9d483318318fe9f982784a7