### PR TITLE
Redirect welcome page to feed and disable dev PWA

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -3,7 +3,8 @@ import withPWAInit from 'next-pwa';
 const withPWA = withPWAInit({
   dest: 'public',
   register: true,
-  swSrc: 'worker/index.ts'
+  swSrc: 'worker/index.ts',
+  disable: process.env.NODE_ENV === 'development'
 });
 
 /** @type {import('next').NextConfig} */

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,17 @@
+import { useEffect } from 'react';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 
 export default function Home() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      router.replace('/feed');
+    }, 1000);
+    return () => clearTimeout(timer);
+  }, [router]);
+
   return (
     <>
       <Head>


### PR DESCRIPTION
## Summary
- auto-route from welcome screen to feed after first load
- disable PWA in development to prevent InjectManifest warnings

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689b2ebf72f48331a29d8feac20823b4