### PR TITLE
Connect to default relays for video feed

### DIFF
--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_RELAYS = [
+  'wss://relay.damus.io',
+  'wss://nos.lol'
+];

--- a/src/features/feed/useVideoFeed.test.ts
+++ b/src/features/feed/useVideoFeed.test.ts
@@ -27,9 +27,12 @@ const sampleEvents: Event[] = [
 
 const filters: Filter[] = [{ kinds: [1] }];
 
+let connectSpy: any;
+
 beforeEach(() => {
   useVideoFeedStore.setState({ metadata: [], currentIndex: 0, key: undefined });
   __clearFeedCache();
+  connectSpy = vi.spyOn(NostrService, 'connect').mockResolvedValue();
 });
 
 afterEach(() => {
@@ -48,6 +51,7 @@ test('setFilters caches results and avoids duplicate subscriptions', async () =>
   await setFilters(filters);
   await setFilters(filters);
   expect(subscribe).toHaveBeenCalledTimes(1);
+  expect(connectSpy).toHaveBeenCalledTimes(1);
 });
 
 test('next and prev update index and preload videos', async () => {

--- a/src/features/feed/useVideoFeed.ts
+++ b/src/features/feed/useVideoFeed.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { useEffect } from 'react';
 import type { Event, Filter } from 'nostr-tools';
 import NostrService from '../../services/nostr';
+import { DEFAULT_RELAYS } from '../../config/relays';
 import { preloadVideo, clearPreloadedVideos } from '../../services/video';
 
 /**
@@ -53,6 +54,7 @@ export const useVideoFeedStore = create<FeedState>((set, get) => ({
     set({ key, currentIndex: 0, metadata: cached });
     preloadAround(0, cached);
 
+    await NostrService.connect(DEFAULT_RELAYS);
     activeUnsub = await NostrService.subscribe(filters, {
       onEvent: (e) => {
         set((state) => {


### PR DESCRIPTION
## Summary
- Add default public relay list
- Ensure video feed connects before subscribing
- Update video feed tests to mock relay connection

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689b3274e6d483318a51153394a40533