### PR TITLE
chore: unregister service worker in dev

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,7 +2,7 @@ import withPWAInit from 'next-pwa';
 
 const withPWA = withPWAInit({
   dest: 'public',
-  register: true,
+  register: process.env.NODE_ENV === 'production',
   swSrc: 'worker/index.ts',
   disable: process.env.NODE_ENV === 'development'
 });

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,15 @@
 import type { AppProps } from 'next/app';
+import { useEffect } from 'react';
 import '@/styles/globals.css';
 
 export default function App({ Component, pageProps }: AppProps) {
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'development' && 'serviceWorker' in navigator) {
+      navigator.serviceWorker.getRegistrations().then((regs) => {
+        regs.forEach((reg) => reg.unregister());
+      });
+    }
+  }, []);
+
   return <Component {...pageProps} />;
 }


### PR DESCRIPTION
## Summary
- unregister existing service workers in development to avoid 404s
- only register service worker in production builds

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689b342ae4688331b1306160a02f8dd5