### PR TITLE
chore: disable build minification

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,7 +9,13 @@ const withPWA = withPWAInit({
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  webpack(config) {
+    // Disable code minification until upstream plugin resolves WebpackError issue
+    // to avoid build failures.
+    config.optimization.minimize = false;
+    return config;
+  }
 };
 
 export default withPWA(nextConfig);


### PR DESCRIPTION
## Summary
- disable webpack minification to avoid WebpackError build failures

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e` *(fails: Host system is missing dependencies to run browsers)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689bad139a048331bee9e3a6fde59f92