### PR TITLE
Display bottom navigation globally

### DIFF
--- a/src/pages/_app.test.ts
+++ b/src/pages/_app.test.ts
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { AppProps } from 'next/app';
+import App from './_app';
+
+vi.mock('@/components/nav/BottomNav', () => ({
+  __esModule: true,
+  default: () => React.createElement('nav', { 'data-testid': 'bottom-nav' }),
+}));
+
+describe('App', () => {
+  it('renders bottom navigation', () => {
+    const Page: AppProps['Component'] = () => React.createElement('div', null, 'Page');
+    const router = {} as any;
+    render(React.createElement(App, { Component: Page, pageProps: {}, router }));
+    expect(screen.getByTestId('bottom-nav')).toBeInTheDocument();
+  });
+});

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import type { AppProps } from 'next/app';
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
+import BottomNav from '@/components/nav/BottomNav';
 import '@/styles/globals.css';
 
 export default function App({ Component, pageProps }: AppProps) {
@@ -11,5 +12,10 @@ export default function App({ Component, pageProps }: AppProps) {
     }
   }, []);
 
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <Component {...pageProps} />
+      <BottomNav />
+    </>
+  );
 }

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -4,7 +4,6 @@ import { motion, AnimatePresence } from 'framer-motion';
 import useVideoFeed from '@/features/feed/useVideoFeed';
 import { createPlayer } from '@/services/video';
 import { CreatorInfo, ActionButtons } from '@/components/video';
-import BottomNav from '@/components/nav/BottomNav';
 
 export default function HomePage() {
   const filters = useMemo<Filter[]>(() => [{ kinds: [1] }], []);
@@ -134,67 +133,64 @@ export default function HomePage() {
   };
 
   return (
-    <>
-      <motion.div
-        className="h-screen w-screen bg-black touch-none"
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
-        onPointerUp={onPointerUp}
-      >
-        <AnimatePresence initial={false} custom={direction}>
-          {currentVideo ? (
-            <motion.div
-              key={currentVideo.id}
-              className="relative h-full w-full overflow-hidden"
-              custom={direction}
-              variants={{
-                enter: (dir: number) => ({ y: dir * 100, opacity: 0 }),
-                center: { y: 0, opacity: 1 },
-                exit: (dir: number) => ({ y: dir * -100, opacity: 0 }),
-              }}
-              initial="enter"
-              animate="center"
-              exit="exit"
-              transition={{ duration: 0.3 }}
-            >
-              <Player />
-              <div className="pointer-events-none absolute inset-0 z-10 flex flex-col justify-between">
-                <CreatorInfo avatarUrl={undefined} creator={creator} caption={caption} />
-                <div className="flex justify-end p-2">
-                  <div className="pointer-events-auto">
-                    <ActionButtons
-                      liked={false}
-                      likeCount={0}
-                      commentCount={0}
-                      zapTotal={0}
-                      onLike={() => {}}
-                      onComment={() => {}}
-                      onShare={() => {}}
-                      onZap={() => {}}
-                    />
-                  </div>
+    <motion.div
+      className="h-screen w-screen bg-black touch-none"
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+    >
+      <AnimatePresence initial={false} custom={direction}>
+        {currentVideo ? (
+          <motion.div
+            key={currentVideo.id}
+            className="relative h-full w-full overflow-hidden"
+            custom={direction}
+            variants={{
+              enter: (dir: number) => ({ y: dir * 100, opacity: 0 }),
+              center: { y: 0, opacity: 1 },
+              exit: (dir: number) => ({ y: dir * -100, opacity: 0 }),
+            }}
+            initial="enter"
+            animate="center"
+            exit="exit"
+            transition={{ duration: 0.3 }}
+          >
+            <Player />
+            <div className="pointer-events-none absolute inset-0 z-10 flex flex-col justify-between">
+              <CreatorInfo avatarUrl={undefined} creator={creator} caption={caption} />
+              <div className="flex justify-end p-2">
+                <div className="pointer-events-auto">
+                  <ActionButtons
+                    liked={false}
+                    likeCount={0}
+                    commentCount={0}
+                    zapTotal={0}
+                    onLike={() => {}}
+                    onComment={() => {}}
+                    onShare={() => {}}
+                    onZap={() => {}}
+                  />
                 </div>
               </div>
-              {indicator && (
-                <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center text-white text-3xl">
-                  {indicator}
-                </div>
-              )}
-            </motion.div>
-          ) : (
-            <motion.p
-              key="loading"
-              className="flex h-full items-center justify-center text-white"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-            >
-              Loading...
-            </motion.p>
-          )}
-        </AnimatePresence>
-      </motion.div>
-      <BottomNav />
-    </>
+            </div>
+            {indicator && (
+              <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center text-white text-3xl">
+                {indicator}
+              </div>
+            )}
+          </motion.div>
+        ) : (
+          <motion.p
+            key="loading"
+            className="flex h-full items-center justify-center text-white"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+          >
+            Loading...
+          </motion.p>
+        )}
+      </AnimatePresence>
+    </motion.div>
   );
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from "path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
   test: {
     include: ["src/**/*.test.ts", "src/**/*.spec.ts"],
     environment: "jsdom",


### PR DESCRIPTION
## Summary
- Render `BottomNav` from `_app` so navigation persists across pages
- Remove duplicate `BottomNav` from `home` page
- Configure Vitest path alias and add test for global nav

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e` *(fails: browserType.launch: Executable doesn't exist; run `pnpm exec playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_689bb5a7c47c8331962efc1bd89ad96d