### PR TITLE
feat: persist feed session and fix navbar visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ pnpm dev
 
 ## Feature Hook Usage
 - **useAuth**: establishes a signer (browser NIP-07 or remote NIP-46) and connects to the user's preferred relays via `NostrService.connect`.
-- **useVideoFeed**: queries initial video events with `NostrService.query` and listens for updates via `NostrService.subscribe`. Components that can tolerate delayed updates may pass a debounce interval to avoid rapid re-renders.
+- **useVideoFeed**: queries initial video events with `NostrService.query` and listens for updates via `NostrService.subscribe`. Components that can tolerate delayed updates may pass a debounce interval to avoid rapid re-renders. The hook persists up to 20 events and the current index in `sessionStorage` so the feed resumes where the user left off.
 - **useZap**: signs and publishes zap events through `NostrService.publish`, also subscribing for zap receipts. The service queues calls per relay so hooks should always reuse it rather than creating their own pool.
 - **useUploadVideo**: uploads media and publishes metadata using `NostrService.publish`, verifying published events with `NostrService.verify`.
 - **Data fetching hooks** should call `NostrService.query` so identical filters share a single in-flight request, preventing parallel relay queries.

--- a/src/components/nav/BottomNav.tsx
+++ b/src/components/nav/BottomNav.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link';
  */
 export default function BottomNav() {
   return (
-    <nav className="pointer-events-auto fixed bottom-0 left-0 right-0 z-20 flex justify-around bg-black/60 p-2 text-white text-xs">
+    <nav className="pointer-events-auto fixed bottom-0 left-0 right-0 z-50 flex justify-around bg-black/60 p-2 text-white text-xs">
       <Link href="/home" className="flex flex-col items-center">
         Home
       </Link>


### PR DESCRIPTION
## Summary
- persist up to 20 feed events and current position in sessionStorage so users resume where they left off
- raise bottom navbar z-index so it reliably displays above video content
- document feed session persistence in README

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e` *(fails: missing Playwright browsers and system dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689bb7f7b7e48331b2cdf22138cbf4e2