### PR TITLE
Avoid cross-origin video validation

### DIFF
--- a/src/services/video.test.tsx
+++ b/src/services/video.test.tsx
@@ -79,32 +79,17 @@ describe("isValidVideoUrl", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns true for reachable video URLs", async () => {
-    (fetch as any).mockResolvedValue({
-      ok: true,
-      headers: { get: () => "video/mp4" }
-    });
+  it("returns true for URLs with a known video extension", async () => {
     await expect(isValidVideoUrl("https://example.com/a.mp4")).resolves.toBe(
       true
     );
-    expect(fetch).toHaveBeenCalledWith("https://example.com/a.mp4", {
-      method: "HEAD"
-    });
+    expect(fetch).not.toHaveBeenCalled();
   });
 
-  it("returns false for non-video content", async () => {
-    (fetch as any).mockResolvedValue({
-      ok: true,
-      headers: { get: () => "text/html" }
-    });
+  it("returns false when URL lacks a video extension", async () => {
     await expect(isValidVideoUrl("https://example.com"))
       .resolves.toBe(false);
-  });
-
-  it("returns false when request fails", async () => {
-    (fetch as any).mockRejectedValue(new Error("fail"));
-    await expect(isValidVideoUrl("https://example.com"))
-      .resolves.toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
   });
 });
 

--- a/src/services/video.tsx
+++ b/src/services/video.tsx
@@ -141,6 +141,20 @@ export async function isValidVideoUrl(url: string): Promise<boolean> {
   try {
     const parsed = new URL(url);
     if (!['http:', 'https:'].includes(parsed.protocol)) return false;
+
+    // Basic extension check to avoid unnecessary network requests
+    const ext = parsed.pathname.split('.').pop()?.toLowerCase();
+    const validExts = ['mp4', 'webm', 'ogg', 'mov', 'm4v'];
+    if (!ext || !validExts.includes(ext)) {
+      urlValidityCache.set(url, false);
+      return false;
+    }
+
+    // Skip cross-origin validation to prevent CORS errors
+    if (typeof window !== 'undefined' && parsed.origin !== window.location.origin) {
+      urlValidityCache.set(url, true);
+      return true;
+    }
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- skip cross-origin HEAD requests in video validation to prevent CORS errors
- add extension-based video checks and update unit tests

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689bbb14826c8331846c5aa15713cd98