### PR TITLE
fix: ensure overlays stack above video

### DIFF
--- a/src/components/nav/BottomNav.tsx
+++ b/src/components/nav/BottomNav.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link';
  */
 export default function BottomNav() {
   return (
-    <nav className="pointer-events-auto fixed bottom-0 left-0 right-0 z-50 flex justify-around bg-black/60 p-2 text-white text-xs">
+    <nav className="pointer-events-auto fixed bottom-0 left-0 right-0 z-50 flex w-full justify-around bg-black/60 p-2 text-white text-xs">
       <Link href="/home" className="flex flex-col items-center">
         Home
       </Link>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -156,7 +156,7 @@ export default function HomePage() {
             transition={{ duration: 0.3 }}
           >
             <Player />
-            <div className="pointer-events-none absolute inset-0 z-10 flex flex-col justify-between">
+            <div className="pointer-events-none absolute inset-0 z-30 flex flex-col justify-between">
               <CreatorInfo avatarUrl={undefined} creator={creator} caption={caption} />
               <div className="flex justify-end p-2">
                 <div className="pointer-events-auto">
@@ -174,7 +174,7 @@ export default function HomePage() {
               </div>
             </div>
             {indicator && (
-              <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center text-white text-3xl">
+              <div className="pointer-events-none absolute inset-0 z-40 flex items-center justify-center text-white text-3xl">
                 {indicator}
               </div>
             )}


### PR DESCRIPTION
## Summary
- position bottom nav with full width so it stays visible
- raise overlay z-index to display action buttons above video

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_689bbd036484833197e63c82245a095b