### PR TITLE
Add time-based filter for video feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Start the Next.js dev server on all network interfaces:
 pnpm dev
 ```
 
+### Configuration
+
+- `NEXT_PUBLIC_FEED_WINDOW_DAYS`: limit the feed to events published within the
+  last _N_ days (defaults to `7`).
+
 ## Feature Hook Usage
 - **useAuth**: establishes a signer (browser NIP-07 or remote NIP-46) and connects to the user's preferred relays via `NostrService.connect`.
 - **useVideoFeed**: queries initial video events with `NostrService.query` and listens for updates via `NostrService.subscribe`. Components that can tolerate delayed updates may pass a debounce interval to avoid rapid re-renders. The hook persists up to 20 events and the current index in `sessionStorage` so the feed resumes where the user left off.

--- a/src/config/feed.test.ts
+++ b/src/config/feed.test.ts
@@ -1,0 +1,15 @@
+import { vi } from 'vitest';
+import { feedSince, FEED_WINDOW_DAYS } from './feed';
+
+describe('feedSince', () => {
+  it('returns timestamp limited by FEED_WINDOW_DAYS', () => {
+    vi.useFakeTimers();
+    const now = new Date('2024-01-08T00:00:00Z');
+    vi.setSystemTime(now);
+    const since = feedSince();
+    const expected = Math.floor(now.getTime() / 1000 - FEED_WINDOW_DAYS * 24 * 60 * 60);
+    expect(since).toBe(expected);
+    vi.useRealTimers();
+  });
+});
+

--- a/src/config/feed.ts
+++ b/src/config/feed.ts
@@ -1,0 +1,10 @@
+const DEFAULT_FEED_WINDOW_DAYS = 7;
+
+export const FEED_WINDOW_DAYS = Number(
+  process.env.NEXT_PUBLIC_FEED_WINDOW_DAYS ?? DEFAULT_FEED_WINDOW_DAYS
+);
+
+export function feedSince(): number {
+  return Math.floor(Date.now() / 1000) - FEED_WINDOW_DAYS * 24 * 60 * 60;
+}
+

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -4,9 +4,13 @@ import { motion, AnimatePresence } from 'framer-motion';
 import useVideoFeed from '@/features/feed/useVideoFeed';
 import { createPlayer } from '@/services/video';
 import { CreatorInfo, ActionButtons } from '@/components/video';
+import { feedSince } from '@/config/feed';
 
 export default function HomePage() {
-  const filters = useMemo<Filter[]>(() => [{ kinds: [1] }], []);
+  const filters = useMemo<Filter[]>(
+    () => [{ kinds: [1], since: feedSince() }],
+    []
+  );
   const { currentVideo, next, prev } = useVideoFeed(filters);
   const [direction, setDirection] = useState(0);
   const handleNext = useCallback(() => {


### PR DESCRIPTION
## Summary
- limit home feed to recent events using a `since` timestamp
- allow configuring age window via `NEXT_PUBLIC_FEED_WINDOW_DAYS`
- document feed time window and add tests for helper

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e` *(fails: navigation and upload specs)*

------
https://chatgpt.com/codex/tasks/task_e_689bc70b36548331891cbe1a5513559d