### PR TITLE
Handle offline navigation failures

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -1,5 +1,6 @@
 import { registerUploadRoute } from '../src/services/storage';
 import { precacheAndRoute } from 'workbox-precaching';
+import { setCatchHandler } from 'workbox-routing';
 
 declare const self: ServiceWorkerGlobalScope & {
   __WB_MANIFEST: Array<{ url: string; revision: string | null }>;
@@ -12,3 +13,10 @@ precacheAndRoute([
 ]);
 
 registerUploadRoute();
+
+setCatchHandler(async ({ event }) => {
+  if (event.request.mode === 'navigate') {
+    return (await caches.match('/')) ?? Response.error();
+  }
+  return Response.error();
+});


### PR DESCRIPTION
## Summary
- return cached root document when navigation requests fail

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689c4354e46c8331826d138017347222