### PR TITLE
Handle video play aborts and unsupported preload "as" value

### DIFF
--- a/src/services/video.tsx
+++ b/src/services/video.tsx
@@ -54,7 +54,11 @@ export function createPlayer(
   };
 
   const play = () => {
-    ref.current?.play?.();
+    ref.current?.play?.().catch((err: any) => {
+      if (err?.name !== 'AbortError') {
+        callbacks.onError?.(err);
+      }
+    });
   };
 
   const pause = () => {
@@ -84,6 +88,10 @@ export function preloadVideo(url?: string): void {
   const link = document.createElement("link");
   link.rel = "preload";
   link.as = "video";
+  if (link.as !== "video") {
+    // Fallback for browsers that don't support video preload
+    link.as = "fetch";
+  }
   link.href = url;
   document.head.appendChild(link);
   preloaded.add(url);
@@ -93,7 +101,9 @@ export function preloadVideo(url?: string): void {
 export function clearPreloadedVideos(): void {
   preloaded.clear();
   Array.from(
-    document.head.querySelectorAll('link[rel="preload"][as="video"]'),
+    document.head.querySelectorAll(
+      'link[rel="preload"][as="video"], link[rel="preload"][as="fetch"]',
+    ),
   ).forEach((el) => el.parentElement?.removeChild(el));
 }
 


### PR DESCRIPTION
## Summary
- handle aborted play() promises and forward other errors
- fallback to `as="fetch"` when browsers don't support `link[rel=preload][as="video"]`

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_689c488c53b483319cc3af39b66603dd