### PR TITLE
refactor: render overlays via portal layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/lodash.debounce": "^4.0.9",
     "@types/node": "^24.2.1",
     "@types/react": "^19.1.9",
+    "@types/react-dom": "19.1.7",
     "autoprefixer": "^10.4.21",
     "babel-loader": "^10.0.0",
     "eslint": "^9.33.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
         version: 6.6.4
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@types/lodash.debounce':
         specifier: ^4.0.9
         version: 4.0.9
@@ -81,6 +81,9 @@ importers:
       '@types/react':
         specifier: ^19.1.9
         version: 19.1.9
+      '@types/react-dom':
+        specifier: 19.1.7
+        version: 19.1.7(@types/react@19.1.9)
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
@@ -1459,6 +1462,11 @@ packages:
 
   '@types/node@24.2.1':
     resolution: {integrity: sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==}
+
+  '@types/react-dom@19.1.7':
+    resolution: {integrity: sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==}
+    peerDependencies:
+      '@types/react': ^19.0.0
 
   '@types/react@19.1.9':
     resolution: {integrity: sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==}
@@ -5474,7 +5482,7 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@babel/runtime': 7.28.2
       '@testing-library/dom': 10.4.1
@@ -5482,6 +5490,7 @@ snapshots:
       react-dom: 19.1.1(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.9
+      '@types/react-dom': 19.1.7(@types/react@19.1.9)
 
   '@tybys/wasm-util@0.10.0':
     dependencies:
@@ -5536,6 +5545,10 @@ snapshots:
   '@types/node@24.2.1':
     dependencies:
       undici-types: 7.10.0
+
+  '@types/react-dom@19.1.7(@types/react@19.1.9)':
+    dependencies:
+      '@types/react': 19.1.9
 
   '@types/react@19.1.9':
     dependencies:

--- a/src/components/Portal.tsx
+++ b/src/components/Portal.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { ReactNode, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+interface PortalProps {
+  children: ReactNode;
+}
+
+export default function Portal({ children }: PortalProps) {
+  const [container, setContainer] = useState<Element | null>(null);
+
+  useEffect(() => {
+    setContainer(document.getElementById('ui-layer'));
+  }, []);
+
+  return container ? createPortal(children, container) : null;
+}
+

--- a/src/components/nav/BottomNav.test.ts
+++ b/src/components/nav/BottomNav.test.ts
@@ -9,6 +9,12 @@ vi.mock('next/link', () => ({
 }));
 
 describe('BottomNav', () => {
+  beforeEach(() => {
+    const uiLayer = document.createElement('div');
+    uiLayer.id = 'ui-layer';
+    document.body.appendChild(uiLayer);
+  });
+
   it('renders navigation links', () => {
     render(React.createElement(BottomNav));
     expect(screen.getByRole('link', { name: /home/i })).toBeInTheDocument();

--- a/src/components/nav/BottomNav.tsx
+++ b/src/components/nav/BottomNav.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Link from 'next/link';
+import Portal from '@/components/Portal';
 
 /**
  * Fixed bottom navigation bar with primary app sections.
@@ -9,16 +10,18 @@ import Link from 'next/link';
  */
 export default function BottomNav() {
   return (
-    <nav className="pointer-events-auto fixed bottom-0 left-0 right-0 z-50 flex w-full justify-around bg-black/60 p-2 text-white text-xs">
-      <Link href="/home" className="flex flex-col items-center">
-        Home
-      </Link>
-      <Link href="/upload" className="flex flex-col items-center">
-        Upload
-      </Link>
-      <Link href="/profile" className="flex flex-col items-center">
-        Profile
-      </Link>
-    </nav>
+    <Portal>
+      <nav className="pointer-events-auto fixed bottom-0 left-0 right-0 z-50 flex w-full justify-around bg-black/60 p-2 text-white text-xs">
+        <Link href="/home" className="flex flex-col items-center">
+          Home
+        </Link>
+        <Link href="/upload" className="flex flex-col items-center">
+          Upload
+        </Link>
+        <Link href="/profile" className="flex flex-col items-center">
+          Profile
+        </Link>
+      </nav>
+    </Portal>
   );
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -15,6 +15,7 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
       <Component {...pageProps} />
+      <div id="ui-layer" />
       <BottomNav />
     </>
   );

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -4,6 +4,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import useVideoFeed from '@/features/feed/useVideoFeed';
 import { createPlayer } from '@/services/video';
 import { CreatorInfo, ActionButtons } from '@/components/video';
+import Portal from '@/components/Portal';
 import { feedSince } from '@/config/feed';
 
 export default function HomePage() {
@@ -160,28 +161,30 @@ export default function HomePage() {
             transition={{ duration: 0.3 }}
           >
             <Player />
-            <div className="pointer-events-none absolute inset-0 z-30 flex flex-col justify-between">
-              <CreatorInfo avatarUrl={undefined} creator={creator} caption={caption} />
-              <div className="flex justify-end p-2">
-                <div className="pointer-events-auto">
-                  <ActionButtons
-                    liked={false}
-                    likeCount={0}
-                    commentCount={0}
-                    zapTotal={0}
-                    onLike={() => {}}
-                    onComment={() => {}}
-                    onShare={() => {}}
-                    onZap={() => {}}
-                  />
+            <Portal>
+              <div className="pointer-events-none fixed inset-0 z-30 flex flex-col justify-between">
+                <CreatorInfo avatarUrl={undefined} creator={creator} caption={caption} />
+                <div className="flex justify-end p-2">
+                  <div className="pointer-events-auto">
+                    <ActionButtons
+                      liked={false}
+                      likeCount={0}
+                      commentCount={0}
+                      zapTotal={0}
+                      onLike={() => {}}
+                      onComment={() => {}}
+                      onShare={() => {}}
+                      onZap={() => {}}
+                    />
+                  </div>
                 </div>
               </div>
-            </div>
-            {indicator && (
-              <div className="pointer-events-none absolute inset-0 z-40 flex items-center justify-center text-white text-3xl">
-                {indicator}
-              </div>
-            )}
+              {indicator && (
+                <div className="pointer-events-none fixed inset-0 z-40 flex items-center justify-center text-white text-3xl">
+                  {indicator}
+                </div>
+              )}
+            </Portal>
           </motion.div>
         ) : (
           <motion.p


### PR DESCRIPTION
## Summary
- add reusable Portal component to mount UI into a top-level layer
- render BottomNav, video overlays, and indicators through the portal to avoid stacking context conflicts
- install `@types/react-dom` for portal typings

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_689c4920705483319a6afc7d03dc7a68