### PR TITLE
Improve bottom navigation layering

### DIFF
--- a/src/components/nav/BottomNav.tsx
+++ b/src/components/nav/BottomNav.tsx
@@ -11,7 +11,7 @@ import Portal from '@/components/Portal';
 export default function BottomNav() {
   return (
     <Portal>
-      <nav className="pointer-events-auto fixed bottom-0 left-0 right-0 z-50 flex w-full justify-around bg-black/60 p-2 text-white text-xs">
+      <nav className="pointer-events-auto fixed bottom-0 left-0 right-0 z-[9999] w-full bg-black/60 p-2 pb-[env(safe-area-inset-bottom)] text-white text-xs flex justify-around">
         <Link href="/home" className="flex flex-col items-center">
           Home
         </Link>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -139,7 +139,7 @@ export default function HomePage() {
 
   return (
     <motion.div
-      className="h-screen w-screen bg-black touch-none"
+      className="relative z-0 h-screen w-screen bg-black touch-none"
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}


### PR DESCRIPTION
## Summary
- make the home screen container a relative stacking context
- raise bottom nav z-index and add safe-area padding

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689c4f7a81348331825ed444ca92db8b