### PR TITLE
Fix video feed URL parsing

### DIFF
--- a/src/features/feed/useVideoFeed.test.ts
+++ b/src/features/feed/useVideoFeed.test.ts
@@ -82,3 +82,22 @@ test('invalid video URLs are ignored', async () => {
   expect(state.metadata[0].id).toBe('1');
 });
 
+test('extracts URL from content with trailing text', async () => {
+  vi.spyOn(NostrService, 'subscribe').mockResolvedValue(() => {});
+  querySpy.mockResolvedValue([
+    {
+      id: '3',
+      kind: 1,
+      pubkey: 'pk3',
+      created_at: 0,
+      sig: 'sig3',
+      tags: [],
+      content: 'https://example.com/c.mp4%F0%9F%93%8A extra',
+    } as Event,
+  ]);
+  const { setFilters } = useVideoFeedStore.getState();
+  await setFilters(filters);
+  const state = useVideoFeedStore.getState();
+  expect(state.metadata[0].content).toBe('https://example.com/c.mp4');
+});
+

--- a/src/features/feed/useVideoFeed.ts
+++ b/src/features/feed/useVideoFeed.ts
@@ -65,9 +65,21 @@ function clearSession(): void {
 }
 
 function getVideoUrlFrom(e: { content: string; tags: string[][] }): string | undefined {
-  const urlTag = e.tags?.find((t) => t[0] === 'url' && t[1] && /^https?:\/\//.test(t[1]));
+  const imeta = e.tags?.find((t) => t[0] === 'imeta');
+  if (imeta) {
+    const urlEntry = imeta.find((s) => s.startsWith('url='));
+    if (urlEntry) return urlEntry.slice(4);
+  }
+
+  const urlTag = e.tags?.find(
+    (t) => t[0] === 'url' && t[1] && /^https?:\/\//.test(t[1]),
+  );
   if (urlTag) return urlTag[1];
-  if (/^https?:\/\//.test(e.content)) return e.content;
+
+  const match = e.content.match(
+    /https?:\/\/\S+?\.(mp4|webm|ogg|mov|m4v|m3u8)/i,
+  );
+  if (match) return match[0];
   return undefined;
 }
 

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -36,6 +36,7 @@ export default function HomePage() {
 
   useEffect(() => {
     if (currentVideo?.content) {
+      console.debug('Video URL:', currentVideo.content, currentVideo);
       load(currentVideo.content);
       play();
       setPlaying(true);


### PR DESCRIPTION
## Summary
- extract video URLs from NIP-94 imeta tags and strip trailing text
- relax video URL validation to inspect URL path and query instead of HEAD fetch
- log video URL when loading videos in home page
- test URL parsing for feeds with trailing text

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm exec playwright install`
- `pnpm exec playwright install-deps`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689c54af524483319e224802d8e68a90